### PR TITLE
Update to GHC 8.8.3

### DIFF
--- a/stack88.yaml
+++ b/stack88.yaml
@@ -1,4 +1,4 @@
-resolver: nightly-2020-02-13
+resolver: nightly-2020-05-26
 packages:
 - .
 extra-deps:


### PR DESCRIPTION
GHC 8.8.3 was released (2020-02-24). I thought it might be a good idea to update the `stack88.yaml`. I'm not aware of possible side effects or complications with `haskell-language-server` (@alanz). Please reject if it might cause trouble :)


https://www.stackage.org/lts-15.5
https://www.haskell.org/ghc/blog/20200224-ghc-8.8.3-released.html