### PR TITLE
Typecheck entire project on Initial Load and typecheck reverse dependencies of a file on saving

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,12 +104,12 @@ If you can't get `ghcide` working outside the editor, see [this setup troublesho
   // When to check the dependents of a module
   // AlwaysCheck means retypechecking them on every change
   // CheckOnSave means dependent/parent modules will only be checked when you save
-  // "CheckOnSave" by default
-  checkParents : "CheckOnSave" | "AlwaysCheck" | "NeverCheck",
+  // "CheckOnSaveAndClose" by default
+  checkParents : "NeverCheck" | "CheckOnClose" | "CheckOnSaveAndClose" | "AlwaysCheck" | ,
   // Whether to check the entire project on initial load
   // true by default
   checkProject : boolean
-   
+
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,24 @@ If you can't get `ghcide` working outside the editor, see [this setup troublesho
 
 `ghcide` has been designed to handle projects with hundreds or thousands of modules. If `ghci` can handle it, then `ghcide` should be able to handle it. The only caveat is that this currently requires GHC >= 8.6, and that the first time a module is loaded in the editor will trigger generation of support files in the background if those do not already exist.
 
+### Configuration
+
+`ghcide` accepts the following lsp configuration options:
+
+```typescript
+{
+  // When to check the dependents of a module
+  // AlwaysCheck means retypechecking them on every change
+  // CheckOnSave means dependent/parent modules will only be checked when you save
+  // "CheckOnSave" by default
+  checkParents : "CheckOnSave" | "AlwaysCheck" | "NeverCheck",
+  // Whether to check the entire project on initial load
+  // true by default
+  checkProject : boolean
+   
+}
+```
+
 ### Using with VS Code
 
 You can install the VSCode extension from the [VSCode

--- a/ghcide.cabal
+++ b/ghcide.cabal
@@ -263,6 +263,7 @@ executable ghcide
                 "-with-rtsopts=-I0 -qg -A128M"
     main-is: Main.hs
     build-depends:
+        aeson,
         base == 4.*,
         data-default,
         directory,
@@ -274,6 +275,7 @@ executable ghcide
         haskell-lsp-types,
         hie-bios >= 0.6.0 && < 0.7,
         ghcide,
+        lens,
         optparse-applicative,
         text,
         unordered-containers

--- a/hie.yaml
+++ b/hie.yaml
@@ -10,6 +10,8 @@ cradle:
               component: "ghcide:lib:ghcide"
             - path: "./exe"
               component: "ghcide:exe:ghcide"
+            - path: "./session-loader"
+              component: "ghcide:lib:ghcide"
             - path: "./test"
               component: "ghcide:test:ghcide-tests"
             - path: "./bench"

--- a/session-loader/Development/IDE/Session.hs
+++ b/session-loader/Development/IDE/Session.hs
@@ -278,7 +278,7 @@ loadSession dir = do
         return (fmap snd as, wait as)
       unless (null cs) $
         -- Typecheck all files in the project on startup
-        void $ shakeEnqueueSession ideSession $ mkDelayedAction "InitialLoad" Info $ void $ do
+        void $ shakeEnqueueSession ideSession $ mkDelayedAction "InitialLoad" Debug $ void $ do
           cfps' <- liftIO $ filterM (IO.doesFileExist . fromNormalizedFilePath) cs
           -- populate the knownFilesVar with all the
           -- files in the project so that `knownFiles` can learn about them and

--- a/session-loader/Development/IDE/Session.hs
+++ b/session-loader/Development/IDE/Session.hs
@@ -103,7 +103,7 @@ loadSession dir = do
     ShakeExtras{logger, eventer, restartShakeSession, withIndefiniteProgress
                ,ideNc, knownFilesVar, session=ideSession} <- getShakeExtras
 
-    IdeOptions{optTesting = IdeTesting optTesting} <- getIdeOptions
+    IdeOptions{optTesting = IdeTesting optTesting, optCheckProject = CheckProject checkProject } <- getIdeOptions
 
     -- Create a new HscEnv from a hieYaml root and a set of options
     -- If the hieYaml file already has an HscEnv, the new component is
@@ -286,7 +286,8 @@ loadSession dir = do
           liftIO $ modifyVar_ knownFilesVar $ traverseHashed $ pure . HashSet.union (HashSet.fromList cfps')
           mmt <- uses GetModificationTime cfps'
           let cs_exist = catMaybes (zipWith (<$) cfps' mmt)
-          uses GetModIface cs_exist
+          when checkProject $
+            void $ uses GetModIface cs_exist
       pure opts
 
 -- | Run the specific cradle on a specific FilePath via hie-bios.

--- a/session-loader/Development/IDE/Session.hs
+++ b/session-loader/Development/IDE/Session.hs
@@ -212,8 +212,6 @@ loadSession dir = do
            -- cradle is
            let progMsg = "Setting up project " <> T.pack (takeBaseName (cradleRootDir cradle))
 
-
-
            eopts <- withIndefiniteProgress progMsg NotCancellable $
              cradleToOptsAndLibDir cradle cfp
 

--- a/session-loader/Development/IDE/Session.hs
+++ b/session-loader/Development/IDE/Session.hs
@@ -25,6 +25,8 @@ import Data.Bifunctor
 import qualified Data.ByteString.Base16 as B16
 import Data.Either.Extra
 import Data.Function
+import qualified Data.HashSet as HashSet
+import Data.Hashable
 import Data.List
 import Data.IORef
 import Data.Maybe
@@ -32,6 +34,7 @@ import Data.Time.Clock
 import Data.Version
 import Development.IDE.Core.OfInterest
 import Development.IDE.Core.Shake
+import Development.IDE.Core.RuleTypes
 import Development.IDE.GHC.Util
 import Development.IDE.Session.VersionCheck
 import Development.IDE.Types.Diagnostics
@@ -47,6 +50,7 @@ import Language.Haskell.LSP.Core
 import Language.Haskell.LSP.Messages
 import Language.Haskell.LSP.Types
 import System.Directory
+import qualified System.Directory.Extra as IO
 import System.FilePath
 import System.Info
 import System.IO
@@ -96,7 +100,9 @@ loadSession dir = do
   runningCradle <- newVar dummyAs :: IO (Var (Async (IdeResult HscEnvEq,[FilePath])))
 
   return $ do
-    ShakeExtras{logger, eventer, restartShakeSession, withIndefiniteProgress, ideNc} <- getShakeExtras
+    ShakeExtras{logger, eventer, restartShakeSession, withIndefiniteProgress
+               ,ideNc, knownFilesVar, session=ideSession} <- getShakeExtras
+
     IdeOptions{optTesting = IdeTesting optTesting} <- getIdeOptions
 
     -- Create a new HscEnv from a hieYaml root and a set of options
@@ -170,7 +176,7 @@ loadSession dir = do
 
 
     let session :: (Maybe FilePath, NormalizedFilePath, ComponentOptions, FilePath)
-                -> IO (IdeResult HscEnvEq,[FilePath])
+                -> IO ([NormalizedFilePath],(IdeResult HscEnvEq,[FilePath]))
         session args@(hieYaml, _cfp, _opts, _libDir) = do
           (hscEnv, new, old_deps) <- packageSetup args
           -- Make a map from unit-id to DynFlags, this is used when trying to
@@ -194,9 +200,9 @@ loadSession dir = do
           invalidateShakeCache
           restartShakeSession [kick]
 
-          return (second Map.keys res)
+          return (map fst cs ++ map fst cached_targets, second Map.keys res)
 
-    let consultCradle :: Maybe FilePath -> FilePath -> IO (IdeResult HscEnvEq, [FilePath])
+    let consultCradle :: Maybe FilePath -> FilePath -> IO ([NormalizedFilePath], (IdeResult HscEnvEq, [FilePath]))
         consultCradle hieYaml cfp = do
            when optTesting $ eventer $ notifyCradleLoaded cfp
            logInfo logger $ T.pack ("Consulting the cradle for " <> show cfp)
@@ -221,7 +227,7 @@ loadSession dir = do
                  InstallationNotFound{..} ->
                      error $ "GHC installation not found in libdir: " <> libdir
                  InstallationMismatch{..} ->
-                     return (([renderPackageSetupException cfp GhcVersionMismatch{..}], Nothing),[])
+                     return ([],(([renderPackageSetupException cfp GhcVersionMismatch{..}], Nothing),[]))
                  InstallationChecked _compileTime _ghcLibCheck ->
                    session (hieYaml, toNormalizedFilePath' cfp, opts, libDir)
              -- Failure case, either a cradle error or the none cradle
@@ -231,11 +237,12 @@ loadSession dir = do
                let res = (map (renderCradleError ncfp) err, Nothing)
                modifyVar_ fileToFlags $ \var -> do
                  pure $ Map.insertWith HM.union hieYaml (HM.singleton ncfp (res, dep_info)) var
-               return (res,[])
+               return ([ncfp],(res,[]))
 
     -- This caches the mapping from hie.yaml + Mod.hs -> [String]
     -- Returns the Ghc session and the cradle dependencies
-    let sessionOpts :: (Maybe FilePath, FilePath) -> IO (IdeResult HscEnvEq, [FilePath])
+    let sessionOpts :: (Maybe FilePath, FilePath)
+                    -> IO ([NormalizedFilePath], (IdeResult HscEnvEq, [FilePath]))
         sessionOpts (hieYaml, file) = do
           v <- fromMaybe HM.empty . Map.lookup hieYaml <$> readVar fileToFlags
           cfp <- canonicalizePath file
@@ -250,25 +257,37 @@ loadSession dir = do
                   -- Keep the same name cache
                   modifyVar_ hscEnvs (return . Map.adjust (\(h, _) -> (h, [])) hieYaml )
                   consultCradle hieYaml cfp
-                else return (opts, Map.keys old_di)
+                else return (HM.keys v, (opts, Map.keys old_di))
             Nothing -> consultCradle hieYaml cfp
 
     -- The main function which gets options for a file. We only want one of these running
     -- at a time. Therefore the IORef contains the currently running cradle, if we try
     -- to get some more options then we wait for the currently running action to finish
     -- before attempting to do so.
-    let getOptions :: FilePath -> IO (IdeResult HscEnvEq, [FilePath])
+    let getOptions :: FilePath -> IO ([NormalizedFilePath],(IdeResult HscEnvEq, [FilePath]))
         getOptions file = do
             hieYaml <- cradleLoc file
             sessionOpts (hieYaml, file) `catch` \e ->
-                return (([renderPackageSetupException file e], Nothing),[])
+                return ([],(([renderPackageSetupException file e], Nothing),[]))
 
     returnWithVersion $ \file -> do
-      liftIO $ join $ mask_ $ modifyVar runningCradle $ \as -> do
+      (cs, opts) <- liftIO $ join $ mask_ $ modifyVar runningCradle $ \as -> do
         -- If the cradle is not finished, then wait for it to finish.
         void $ wait as
         as <- async $ getOptions file
-        return (as, wait as)
+        return (fmap snd as, wait as)
+      unless (null cs) $
+        -- Typecheck all files in the project on startup
+        void $ shakeEnqueueSession ideSession $ mkDelayedAction "InitialLoad" Info $ void $ do
+          cfps' <- liftIO $ filterM (IO.doesFileExist . fromNormalizedFilePath) cs
+          -- populate the knownFilesVar with all the
+          -- files in the project so that `knownFiles` can learn about them and
+          -- we can generate a complete module graph
+          liftIO $ modifyVar_ knownFilesVar $ traverseHashed $ pure . HashSet.union (HashSet.fromList cfps')
+          mmt <- uses GetModificationTime cfps'
+          let cs_exist = catMaybes (zipWith (<$) cfps' mmt)
+          uses GetModIface cs_exist
+      pure opts
 
 -- | Run the specific cradle on a specific FilePath via hie-bios.
 -- This then builds dependencies or whatever based on the cradle, gets the

--- a/src/Development/IDE/Core/OfInterest.hs
+++ b/src/Development/IDE/Core/OfInterest.hs
@@ -80,8 +80,6 @@ modifyFilesOfInterest state f = do
     OfInterestVar var <- getIdeGlobalState state
     files <- modifyVar var $ pure . dupe . f
     logDebug (ideLogger state) $ "Set files of interest to: " <> T.pack (show $ HashSet.toList files)
-    let das = map (\nfp -> mkDelayedAction "OfInterest" Debug (use GetSpanInfo nfp)) (HashSet.toList files)
-    shakeRestart state das
 
 -- | Typecheck all the files of interest.
 --   Could be improved

--- a/src/Development/IDE/Core/RuleTypes.hs
+++ b/src/Development/IDE/Core/RuleTypes.hs
@@ -46,11 +46,14 @@ type instance RuleResult GetDependencyInformation = DependencyInformation
 -- This rule is also responsible for calling ReportImportCycles for each file in the transitive closure.
 type instance RuleResult GetDependencies = TransitiveDependencies
 
+type instance RuleResult GetModuleGraph = DependencyInformation
+
 -- | Contains the typechecked module and the OrigNameCache entry for
 -- that module.
 data TcModuleResult = TcModuleResult
     { tmrModule     :: TypecheckedModule
     , tmrModInfo    :: HomeModInfo
+    , tmrDeferedError :: !Bool -- ^ Did we defer any type errors for this module?
     }
 instance Show TcModuleResult where
     show = show . pm_mod_summary . tm_parsed_module . tmrModule
@@ -144,6 +147,12 @@ data GetDependencyInformation = GetDependencyInformation
 instance Hashable GetDependencyInformation
 instance NFData   GetDependencyInformation
 instance Binary   GetDependencyInformation
+
+data GetModuleGraph = GetModuleGraph
+    deriving (Eq, Show, Typeable, Generic)
+instance Hashable GetModuleGraph
+instance NFData   GetModuleGraph
+instance Binary   GetModuleGraph
 
 data ReportImportCycles = ReportImportCycles
     deriving (Eq, Show, Typeable, Generic)

--- a/src/Development/IDE/Core/RuleTypes.hs
+++ b/src/Development/IDE/Core/RuleTypes.hs
@@ -19,6 +19,7 @@ import Development.IDE.GHC.Util
 import           Data.Hashable
 import           Data.Typeable
 import qualified Data.Set as S
+import qualified Data.HashSet                             as HS
 import           Development.Shake
 import           GHC.Generics                             (Generic)
 
@@ -28,6 +29,7 @@ import HscTypes (hm_iface, CgGuts, Linkable, HomeModInfo, ModDetails)
 import           Development.IDE.Spans.Type
 import           Development.IDE.Import.FindImports (ArtifactsLocation)
 import Data.ByteString (ByteString)
+import Language.Haskell.LSP.Types (NormalizedFilePath)
 
 
 -- NOTATION
@@ -47,6 +49,13 @@ type instance RuleResult GetDependencyInformation = DependencyInformation
 type instance RuleResult GetDependencies = TransitiveDependencies
 
 type instance RuleResult GetModuleGraph = DependencyInformation
+
+data GetKnownFiles = GetKnownFiles
+  deriving (Show, Generic, Eq, Ord)
+instance Hashable GetKnownFiles
+instance NFData   GetKnownFiles
+instance Binary   GetKnownFiles
+type instance RuleResult GetKnownFiles = HS.HashSet NormalizedFilePath
 
 -- | Contains the typechecked module and the OrigNameCache entry for
 -- that module.

--- a/src/Development/IDE/Core/Rules.hs
+++ b/src/Development/IDE/Core/Rules.hs
@@ -57,6 +57,7 @@ import qualified Data.IntMap.Strict as IntMap
 import Data.IntMap.Strict (IntMap)
 import Data.List
 import qualified Data.Set                                 as Set
+import qualified Data.HashSet                             as HS
 import qualified Data.Text                                as T
 import           Development.IDE.GHC.Error
 import           Development.Shake                        hiding (Diagnostic)
@@ -87,6 +88,7 @@ import Control.Monad.State
 import FastString (FastString(uniq))
 import qualified HeaderInfo as Hdr
 import Data.Time (UTCTime(..))
+import Data.Hashable
 
 -- | This is useful for rules to convert rules that can only produce errors or
 -- a result into the more general IdeResult type that supports producing
@@ -500,6 +502,25 @@ typeCheckRule = define $ \TypeCheck file -> do
     -- for files of interest on every keystroke
     typeCheckRuleDefinition hsc pm SkipGenerationOfInterfaceFiles
 
+data GetKnownFiles = GetKnownFiles
+  deriving (Show, Generic, Eq, Ord)
+instance Hashable GetKnownFiles
+instance NFData   GetKnownFiles
+instance Binary   GetKnownFiles
+type instance RuleResult GetKnownFiles = HS.HashSet NormalizedFilePath
+
+knownFilesRule :: Rules ()
+knownFilesRule = defineEarlyCutOffNoFile $ \GetKnownFiles -> do
+  alwaysRerun
+  fs <- knownFiles
+  pure (BS.pack (show $ hash fs), unhashed fs)
+
+getModuleGraphRule :: Rules ()
+getModuleGraphRule = defineNoFile $ \GetModuleGraph -> do
+  fs <- useNoFile_ GetKnownFiles
+  rawDepInfo <- rawDependencyInformation (HS.toList fs)
+  pure $ processDependencyInformation rawDepInfo
+
 data GenerateInterfaceFiles
     = DoGenerateInterfaceFiles
     | SkipGenerationOfInterfaceFiles
@@ -521,9 +542,14 @@ typeCheckRuleDefinition hsc pm generateArtifacts = do
   addUsageDependencies $ liftIO $ do
     res <- typecheckModule defer hsc pm
     case res of
-      (diags, Just (hsc,tcm)) | DoGenerateInterfaceFiles <- generateArtifacts -> do
+      (diags, Just (hsc,tcm))
+        | DoGenerateInterfaceFiles <- generateArtifacts
+        -- Don't save interface files for modules that compiled due to defering
+        -- type errors, as we won't get proper diagnostics if we load these from
+        -- disk
+        , not $ tmrDeferedError tcm -> do
         diagsHie <- generateAndWriteHieFile hsc (tmrModule tcm)
-        diagsHi  <- generateAndWriteHiFile hsc tcm
+        diagsHi  <- writeHiFile hsc tcm
         return (diags <> diagsHi <> diagsHie, Just tcm)
       (diags, res) ->
         return (diags, snd <$> res)
@@ -802,6 +828,8 @@ mainRule = do
     isFileOfInterestRule
     getModSummaryRule
     isHiFileStableRule
+    getModuleGraphRule
+    knownFilesRule
 
 -- | Given the path to a module src file, this rule returns True if the
 -- corresponding `.hi` file is stable, that is, if it is newer

--- a/src/Development/IDE/Core/Rules.hs
+++ b/src/Development/IDE/Core/Rules.hs
@@ -57,7 +57,6 @@ import qualified Data.IntMap.Strict as IntMap
 import Data.IntMap.Strict (IntMap)
 import Data.List
 import qualified Data.Set                                 as Set
-import qualified Data.HashSet                             as HS
 import qualified Data.Text                                as T
 import           Development.IDE.GHC.Error
 import           Development.Shake                        hiding (Diagnostic)
@@ -507,13 +506,6 @@ typeCheckRule = define $ \TypeCheck file -> do
     -- for files of interest on every keystroke
     typeCheckRuleDefinition hsc pm SkipGenerationOfInterfaceFiles
 
-data GetKnownFiles = GetKnownFiles
-  deriving (Show, Generic, Eq, Ord)
-instance Hashable GetKnownFiles
-instance NFData   GetKnownFiles
-instance Binary   GetKnownFiles
-type instance RuleResult GetKnownFiles = HS.HashSet NormalizedFilePath
-
 knownFilesRule :: Rules ()
 knownFilesRule = defineEarlyCutOffNoFile $ \GetKnownFiles -> do
   alwaysRerun
@@ -523,7 +515,7 @@ knownFilesRule = defineEarlyCutOffNoFile $ \GetKnownFiles -> do
 getModuleGraphRule :: Rules ()
 getModuleGraphRule = defineNoFile $ \GetModuleGraph -> do
   fs <- useNoFile_ GetKnownFiles
-  rawDepInfo <- rawDependencyInformation (HS.toList fs)
+  rawDepInfo <- rawDependencyInformation (HashSet.toList fs)
   pure $ processDependencyInformation rawDepInfo
 
 data GenerateInterfaceFiles

--- a/src/Development/IDE/GHC/Util.hs
+++ b/src/Development/IDE/GHC/Util.hs
@@ -6,6 +6,7 @@ module Development.IDE.GHC.Util(
     -- * HcsEnv and environment
     HscEnvEq,
     hscEnv, newHscEnvEq,
+    hscEnvWithImportPaths,
     modifyDynFlags,
     evalGhcEnv,
     runGhcEnv,
@@ -169,36 +170,46 @@ moduleImportPath (takeDirectory . fromNormalizedFilePath -> pathDir) mn
 
 -- | An 'HscEnv' with equality. Two values are considered equal
 --   if they are created with the same call to 'newHscEnvEq'.
-data HscEnvEq
-    = HscEnvEq !Unique !HscEnv
-               [(InstalledUnitId, DynFlags)] -- In memory components for this HscEnv
+data HscEnvEq = HscEnvEq
+    { envUnique :: !Unique
+    , hscEnv :: !HscEnv
+    , deps   :: [(InstalledUnitId, DynFlags)]
+               -- ^ In memory components for this HscEnv
                -- This is only used at the moment for the import dirs in
                -- the DynFlags
-
--- | Unwrap an 'HsEnvEq'.
-hscEnv :: HscEnvEq -> HscEnv
-hscEnv = either error id . hscEnv'
-
-hscEnv' :: HscEnvEq -> Either String HscEnv
-hscEnv' (HscEnvEq _ x _) = Right x
-deps :: HscEnvEq -> [(InstalledUnitId, DynFlags)]
-deps (HscEnvEq _ _ u) = u
+    , envImportPaths :: [String]
+        -- ^ Import dirs originally configured in this env
+        --   We remove them to prevent GHC from loading modules on its own
+    }
 
 -- | Wrap an 'HscEnv' into an 'HscEnvEq'.
 newHscEnvEq :: HscEnv -> [(InstalledUnitId, DynFlags)] -> IO HscEnvEq
-newHscEnvEq e uids = do u <- newUnique; return $ HscEnvEq u e uids
+newHscEnvEq hscEnv0 deps = do
+    envUnique <- newUnique
+    let envImportPaths = importPaths $ hsc_dflags hscEnv0
+        hscEnv = removeImportPaths hscEnv0
+    return HscEnvEq{..}
+
+-- | Unwrap the 'HscEnv' with the original import paths.
+--   Used only for locating imports
+hscEnvWithImportPaths :: HscEnvEq -> HscEnv
+hscEnvWithImportPaths HscEnvEq{..} =
+    hscEnv{hsc_dflags = (hsc_dflags hscEnv){importPaths = envImportPaths}}
+
+removeImportPaths :: HscEnv -> HscEnv
+removeImportPaths hsc = hsc{hsc_dflags = (hsc_dflags hsc){importPaths = []}}
 
 instance Show HscEnvEq where
-  show (HscEnvEq a _ _) = "HscEnvEq " ++ show (hashUnique a)
+  show HscEnvEq{envUnique} = "HscEnvEq " ++ show (hashUnique envUnique)
 
 instance Eq HscEnvEq where
-  HscEnvEq a _ _ == HscEnvEq b _ _ = a == b
+  a == b = envUnique a == envUnique b
 
 instance NFData HscEnvEq where
-  rnf (HscEnvEq a b c) = rnf (hashUnique a) `seq` b `seq` c `seq` ()
+  rnf (HscEnvEq a b c d) = rnf (hashUnique a) `seq` b `seq` c `seq` rnf d
 
 instance Hashable HscEnvEq where
-  hashWithSalt s (HscEnvEq a _b _c) = hashWithSalt s a
+  hashWithSalt s = hashWithSalt s . envUnique
 
 -- Fake instance needed to persuade Shake to accept this type as a key.
 -- No harm done as ghcide never persists these keys currently

--- a/src/Development/IDE/Import/DependencyInformation.hs
+++ b/src/Development/IDE/Import/DependencyInformation.hs
@@ -21,6 +21,7 @@ module Development.IDE.Import.DependencyInformation
   , reachableModules
   , processDependencyInformation
   , transitiveDeps
+  , reverseDependencies
 
   , BootIdMap
   , insertBootId
@@ -142,6 +143,8 @@ data DependencyInformation =
     , depModuleDeps :: !(FilePathIdMap FilePathIdSet)
     -- ^ For a non-error node, this contains the set of module immediate dependencies
     -- in the same package.
+    , depReverseModuleDeps :: !(IntMap IntSet)
+    -- ^ Contains a reverse mapping from a module to all those that immediately depend on it.
     , depPkgDeps :: !(FilePathIdMap (Set InstalledUnitId))
     -- ^ For a non-error node, this contains the set of immediate pkg deps.
     , depPathIdMap :: !PathIdMap
@@ -222,6 +225,7 @@ processDependencyInformation rawDepInfo@RawDependencyInformation{..} =
   DependencyInformation
     { depErrorNodes = IntMap.fromList errorNodes
     , depModuleDeps = moduleDeps
+    , depReverseModuleDeps = reverseModuleDeps
     , depModuleNames = IntMap.fromList $ coerce moduleNames
     , depPkgDeps = pkgDependencies rawDepInfo
     , depPathIdMap = rawPathIdMap
@@ -232,15 +236,20 @@ processDependencyInformation rawDepInfo@RawDependencyInformation{..} =
         moduleNames :: [(FilePathId, ModuleName)]
         moduleNames =
           [ (fId, modName) | (_, imports) <- successNodes, (L _ modName, fId) <- imports]
-        successEdges :: [(FilePathId, FilePathId, [FilePathId])]
+        successEdges :: [(FilePathId, [FilePathId])]
         successEdges =
             map
-              (\(file, imports) -> (FilePathId file, FilePathId file, map snd imports))
+              (bimap FilePathId (map snd))
               successNodes
         moduleDeps =
           IntMap.fromList $
-          map (\(_, FilePathId v, vs) -> (v, IntSet.fromList $ coerce vs))
+          map (\(FilePathId v, vs) -> (v, IntSet.fromList $ coerce vs))
             successEdges
+        reverseModuleDeps =
+          foldr (\(p, cs) res ->
+                                  let new = IntMap.fromList (map (, IntSet.singleton (coerce p)) (coerce cs))
+                                  in IntMap.unionWith IntSet.union new res ) IntMap.empty successEdges
+
 
 -- | Given a dependency graph, buildResultGraph detects and propagates errors in that graph as follows:
 -- 1. Mark each node that is part of an import cycle as an error node.
@@ -306,6 +315,18 @@ partitionSCC (CyclicSCC xs:rest) = second (xs:) $ partitionSCC rest
 partitionSCC (AcyclicSCC x:rest) = first (x:)   $ partitionSCC rest
 partitionSCC []                  = ([], [])
 
+-- | Transitive reverse dependencies of a file
+reverseDependencies :: NormalizedFilePath -> DependencyInformation -> [NormalizedFilePath]
+reverseDependencies file DependencyInformation{..} =
+  let FilePathId cur_id = pathToId depPathIdMap file
+  in map (idToPath depPathIdMap . FilePathId) (IntSet.toList (go cur_id IntSet.empty))
+  where
+    go :: Int -> IntSet -> IntSet
+    go k i =
+      let outwards = fromMaybe IntSet.empty (IntMap.lookup k depReverseModuleDeps  )
+          res = IntSet.union i outwards
+          new = IntSet.difference i outwards
+      in IntSet.foldr go res new
 
 transitiveDeps :: DependencyInformation -> NormalizedFilePath -> Maybe TransitiveDependencies
 transitiveDeps DependencyInformation{..} file = do

--- a/src/Development/IDE/LSP/LanguageServer.hs
+++ b/src/Development/IDE/LSP/LanguageServer.hs
@@ -46,7 +46,7 @@ runLanguageServer
     -> (InitializeRequest -> Either T.Text config)
     -> (DidChangeConfigurationNotification -> Either T.Text config)
     -> (IO LspId -> (FromServerMessage -> IO ()) -> VFSHandle -> ClientCapabilities
-        -> WithProgressFunc -> WithIndefiniteProgressFunc -> IO IdeState)
+        -> WithProgressFunc -> WithIndefiniteProgressFunc -> IO (Maybe config) -> IO IdeState)
     -> IO ()
 runLanguageServer options userHandlers onInitialConfig onConfigChange getIdeState = do
     -- Move stdout to another file descriptor and duplicate stderr
@@ -133,7 +133,7 @@ runLanguageServer options userHandlers onInitialConfig onConfigChange getIdeStat
         handleInit exitClientMsg clearReqId waitForCancel clientMsgChan lspFuncs@LSP.LspFuncs{..} = do
 
             ide <- getIdeState getNextReqId sendFunc (makeLSPVFSHandle lspFuncs) clientCapabilities
-                               withProgress withIndefiniteProgress
+                               withProgress withIndefiniteProgress config
 
             _ <- flip forkFinally (const exitClientMsg) $ forever $ do
                 msg <- readChan clientMsgChan

--- a/src/Development/IDE/LSP/Notifications.hs
+++ b/src/Development/IDE/LSP/Notifications.hs
@@ -24,7 +24,7 @@ import           Data.Maybe
 import qualified Data.HashSet                     as S
 import qualified Data.Text                        as Text
 
-import           Development.IDE.Core.FileStore   (setSomethingModified, setFileModified)
+import           Development.IDE.Core.FileStore   (setSomethingModified, setFileModified, typecheckParents)
 import           Development.IDE.Core.FileExists  (modifyFileExists)
 import           Development.IDE.Core.OfInterest
 
@@ -39,24 +39,26 @@ setHandlersNotifications = PartialHandlers $ \WithMessage{..} x -> return x
             updatePositionMapping ide (VersionedTextDocumentIdentifier _uri (Just _version)) (List [])
             whenUriFile _uri $ \file -> do
                 modifyFilesOfInterest ide (S.insert file)
-                setFileModified ide file
+                setFileModified ide True file
                 logInfo (ideLogger ide) $ "Opened text document: " <> getUri _uri
 
     ,LSP.didChangeTextDocumentNotificationHandler = withNotification (LSP.didChangeTextDocumentNotificationHandler x) $
         \_ ide (DidChangeTextDocumentParams identifier@VersionedTextDocumentIdentifier{_uri} changes) -> do
             updatePositionMapping ide identifier changes
-            whenUriFile _uri $ \file -> setFileModified ide file
+            whenUriFile _uri $ \file -> setFileModified ide False file
             logInfo (ideLogger ide) $ "Modified text document: " <> getUri _uri
 
     ,LSP.didSaveTextDocumentNotificationHandler = withNotification (LSP.didSaveTextDocumentNotificationHandler x) $
         \_ ide (DidSaveTextDocumentParams TextDocumentIdentifier{_uri}) -> do
-            whenUriFile _uri $ \file -> setFileModified ide file
+            whenUriFile _uri $ \file -> setFileModified ide True file
             logInfo (ideLogger ide) $ "Saved text document: " <> getUri _uri
 
     ,LSP.didCloseTextDocumentNotificationHandler = withNotification (LSP.didCloseTextDocumentNotificationHandler x) $
         \_ ide (DidCloseTextDocumentParams TextDocumentIdentifier{_uri}) -> do
             whenUriFile _uri $ \file -> do
                 modifyFilesOfInterest ide (S.delete file)
+                -- Refresh all the files that depended on this
+                typecheckParents ide file
                 logInfo (ideLogger ide) $ "Closed text document: " <> getUri _uri
     ,LSP.didChangeWatchedFilesNotificationHandler = withNotification (LSP.didChangeWatchedFilesNotificationHandler x) $
         \_ ide (DidChangeWatchedFilesParams fileEvents) -> do

--- a/src/Development/IDE/LSP/Notifications.hs
+++ b/src/Development/IDE/LSP/Notifications.hs
@@ -39,28 +39,25 @@ setHandlersNotifications = PartialHandlers $ \WithMessage{..} x -> return x
     {LSP.didOpenTextDocumentNotificationHandler = withNotification (LSP.didOpenTextDocumentNotificationHandler x) $
         \_ ide (DidOpenTextDocumentParams TextDocumentItem{_uri,_version}) -> do
             updatePositionMapping ide (VersionedTextDocumentIdentifier _uri (Just _version)) (List [])
+            IdeOptions{optCheckParents} <- getIdeOptionsIO $ shakeExtras ide
             whenUriFile _uri $ \file -> do
                 modifyFilesOfInterest ide (S.insert file)
-                setFileModified ide True file
+                let checkParents = optCheckParents == AlwaysCheck
+                setFileModified ide checkParents file
                 logInfo (ideLogger ide) $ "Opened text document: " <> getUri _uri
 
     ,LSP.didChangeTextDocumentNotificationHandler = withNotification (LSP.didChangeTextDocumentNotificationHandler x) $
         \_ ide (DidChangeTextDocumentParams identifier@VersionedTextDocumentIdentifier{_uri} changes) -> do
             updatePositionMapping ide identifier changes
             IdeOptions{optCheckParents} <- getIdeOptionsIO $ shakeExtras ide
-            let checkParents = case optCheckParents of
-                  AlwaysCheck -> True
-                  _ -> False
+            let checkParents = optCheckParents == AlwaysCheck
             whenUriFile _uri $ \file -> setFileModified ide checkParents file
             logInfo (ideLogger ide) $ "Modified text document: " <> getUri _uri
 
     ,LSP.didSaveTextDocumentNotificationHandler = withNotification (LSP.didSaveTextDocumentNotificationHandler x) $
         \_ ide (DidSaveTextDocumentParams TextDocumentIdentifier{_uri}) -> do
             IdeOptions{optCheckParents} <- getIdeOptionsIO $ shakeExtras ide
-            let checkParents = case optCheckParents of
-                  AlwaysCheck -> True
-                  CheckOnSave -> True
-                  _ -> False
+            let checkParents = optCheckParents >= CheckOnSaveAndClose
             whenUriFile _uri $ \file -> setFileModified ide checkParents file
             logInfo (ideLogger ide) $ "Saved text document: " <> getUri _uri
 
@@ -69,7 +66,8 @@ setHandlersNotifications = PartialHandlers $ \WithMessage{..} x -> return x
             whenUriFile _uri $ \file -> do
                 modifyFilesOfInterest ide (S.delete file)
                 -- Refresh all the files that depended on this
-                typecheckParents ide file
+                IdeOptions{optCheckParents} <- getIdeOptionsIO $ shakeExtras ide
+                when (optCheckParents >= CheckOnClose) $ typecheckParents ide file
                 logInfo (ideLogger ide) $ "Closed text document: " <> getUri _uri
     ,LSP.didChangeWatchedFilesNotificationHandler = withNotification (LSP.didChangeWatchedFilesNotificationHandler x) $
         \_ ide (DidChangeWatchedFilesParams fileEvents) -> do

--- a/src/Development/IDE/Types/Options.hs
+++ b/src/Development/IDE/Types/Options.hs
@@ -93,7 +93,13 @@ data IdeOptions = IdeOptions
 newtype CheckProject = CheckProject { shouldCheckProject :: Bool }
   deriving stock (Eq, Ord, Show)
   deriving newtype (FromJSON,ToJSON)
-data CheckParents = AlwaysCheck | NeverCheck | CheckOnSave
+data CheckParents
+    -- Note that ordering of constructors is meaningful and must be monotonically
+    -- increasing in the scenarios where parents are checked
+    = NeverCheck
+    | CheckOnClose
+    | CheckOnSaveAndClose
+    | AlwaysCheck
   deriving stock (Eq, Ord, Show, Generic)
   deriving anyclass (FromJSON, ToJSON)
 
@@ -105,7 +111,7 @@ data LspConfig
     deriving anyclass (FromJSON, ToJSON)
 
 defaultLspConfig :: LspConfig
-defaultLspConfig = LspConfig CheckOnSave (CheckProject True)
+defaultLspConfig = LspConfig CheckOnSaveAndClose (CheckProject True)
 
 data IdePreprocessedSource = IdePreprocessedSource
   { preprocWarnings :: [(GHC.SrcSpan, String)]
@@ -139,8 +145,8 @@ defaultIdeOptions session = IdeOptions
     ,optKeywords = haskellKeywords
     ,optDefer = IdeDefer True
     ,optTesting = IdeTesting False
-    ,optCheckProject = CheckProject True
-    ,optCheckParents = CheckOnSave
+    ,optCheckProject = checkProject defaultLspConfig
+    ,optCheckParents = checkParents defaultLspConfig
     }
 
 

--- a/src/Development/IDE/Types/Options.hs
+++ b/src/Development/IDE/Types/Options.hs
@@ -6,6 +6,8 @@
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DerivingStrategies #-}
 
+{- HLINT ignore "Avoid restricted extensions" -}
+
 -- | Options
 module Development.IDE.Types.Options
   ( IdeOptions(..)

--- a/src/Development/IDE/Types/Options.hs
+++ b/src/Development/IDE/Types/Options.hs
@@ -2,6 +2,9 @@
 -- SPDX-License-Identifier: Apache-2.0
 
 {-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DerivingStrategies #-}
 
 -- | Options
 module Development.IDE.Types.Options
@@ -15,6 +18,10 @@ module Development.IDE.Types.Options
   , defaultIdeOptions
   , IdeResult
   , IdeGhcSession(..)
+  , LspConfig(..)
+  , defaultLspConfig
+  , CheckProject(..)
+  , CheckParents(..)
   ) where
 
 import Development.Shake
@@ -25,6 +32,8 @@ import qualified Language.Haskell.LSP.Types.Capabilities as LSP
 import qualified Data.Text as T
 import Development.IDE.Types.Diagnostics
 import Control.DeepSeq (NFData(..))
+import Data.Aeson
+import GHC.Generics
 
 data IdeGhcSession = IdeGhcSession
   { loadSessionFun :: FilePath -> IO (IdeResult HscEnvEq, [FilePath])
@@ -73,7 +82,28 @@ data IdeOptions = IdeOptions
     --   features such as diagnostics and go-to-definition, in
     --   situations in which they would become unavailable because of
     --   the presence of type errors, holes or unbound variables.
+  , optCheckProject :: CheckProject
+    -- ^ Whether to typecheck the entire project on load
+  , optCheckParents :: CheckParents
+    -- ^ When to typecheck reverse dependencies of a file
   }
+
+newtype CheckProject = CheckProject { shouldCheckProject :: Bool }
+  deriving stock (Eq, Ord, Show)
+  deriving newtype (FromJSON,ToJSON)
+data CheckParents = AlwaysCheck | NeverCheck | CheckOnSave
+  deriving stock (Eq, Ord, Show, Generic)
+  deriving anyclass (FromJSON, ToJSON)
+
+data LspConfig
+  = LspConfig
+  { checkParents :: CheckParents
+  , checkProject :: CheckProject
+  } deriving stock (Eq, Ord, Show, Generic)
+    deriving anyclass (FromJSON, ToJSON)
+
+defaultLspConfig :: LspConfig
+defaultLspConfig = LspConfig CheckOnSave (CheckProject True)
 
 data IdePreprocessedSource = IdePreprocessedSource
   { preprocWarnings :: [(GHC.SrcSpan, String)]
@@ -107,6 +137,8 @@ defaultIdeOptions session = IdeOptions
     ,optKeywords = haskellKeywords
     ,optDefer = IdeDefer True
     ,optTesting = IdeTesting False
+    ,optCheckProject = CheckProject True
+    ,optCheckParents = CheckOnSave
     }
 
 


### PR DESCRIPTION
It is useful to show diagnostics for all files in a project when it is initially loaded.

It is also useful to propagate changes we make in one file to other files which depend on the file we have changed. We only trigger this on saves to avoid annoying users with a barrage of errors, which is also helpful for IDE speed and responsiveness as we don't want to potentially recompile the entire project on every keystroke.

This reduces dependence on `kick`, as we can precisely target the files we need to reload.

Also fixed a bug where we would cache the iface of a file that compiled due to `-fdefer-type-errors`. Due to this, on subsequent runs of `ghcide`, we would not get diagnostics for those files. This is also essential to make the parent type-checking stuff work as expected.