### PR TITLE
Generate doc file URL via LSP (to fix it for Windows)

### DIFF
--- a/src/Development/IDE/Spans/Documentation.hs
+++ b/src/Development/IDE/Spans/Documentation.hs
@@ -31,6 +31,7 @@ import           SrcLoc (RealLocated)
 import           GhcMonad
 import           Packages
 import           Name
+import           Language.Haskell.LSP.Types (getUri, filePathToUri)
 
 getDocumentationTryGhc :: GhcMonad m => Module -> [ParsedModule] -> Name -> m SpanDoc
 getDocumentationTryGhc mod deps n = head <$> getDocumentationsTryGhc mod deps [n]
@@ -55,24 +56,25 @@ getDocumentationsTryGhc _ sources names = mapM mkSpanDocText names
 #endif
     mkSpanDocText name =
       pure (SpanDocText (getDocumentation sources name)) <*> getUris name
-
+   
     -- Get the uris to the documentation and source html pages if they exist
     getUris name = do
       df <- getSessionDynFlags
-      (docFp, srcFp) <-
+      (docFu, srcFu) <-
         case nameModule_maybe name of
           Just mod -> liftIO $ do
-            doc <- fmap (fmap T.pack) $ lookupDocHtmlForModule df mod
-            src <- fmap (fmap T.pack) $ lookupSrcHtmlForModule df mod
+            doc <- toFileUriText $ lookupDocHtmlForModule df mod
+            src <- toFileUriText $ lookupSrcHtmlForModule df mod
             return (doc, src)
           Nothing -> pure (Nothing, Nothing)
-      let docUri = docFp >>= \fp -> pure $ "file:///" <> fp <> "#" <> selector <> showName name
-          srcUri = srcFp >>= \fp -> pure $ "file:///" <> fp <> "#" <> showName name
+      let docUri = (<> "#" <> selector <> showName name) <$> docFu
+          srcUri = (<> "#" <> showName name) <$> srcFu
           selector
             | isValName name = "v:"
             | otherwise = "t:"
       return $ SpanDocUris docUri srcUri
 
+    toFileUriText = (fmap . fmap) (getUri . filePathToUri)
 
 getDocumentation
  :: HasSrcSpan name

--- a/src/Development/IDE/Spans/Documentation.hs
+++ b/src/Development/IDE/Spans/Documentation.hs
@@ -66,8 +66,8 @@ getDocumentationsTryGhc _ sources names = mapM mkSpanDocText names
             src <- fmap (fmap T.pack) $ lookupSrcHtmlForModule df mod
             return (doc, src)
           Nothing -> pure (Nothing, Nothing)
-      let docUri = docFp >>= \fp -> pure $ "file://" <> fp <> "#" <> selector <> showName name
-          srcUri = srcFp >>= \fp -> pure $ "file://" <> fp <> "#" <> showName name
+      let docUri = docFp >>= \fp -> pure $ "file:///" <> fp <> "#" <> selector <> showName name
+          srcUri = srcFp >>= \fp -> pure $ "file:///" <> fp <> "#" <> showName name
           selector
             | isValName name = "v:"
             | otherwise = "t:"

--- a/test/exe/Main.hs
+++ b/test/exe/Main.hs
@@ -2032,7 +2032,7 @@ findDefinitionAndHoverTests = let
   lstL43 = Position 47 12  ;  litL   = [ExpectHoverText ["[8391 :: Int, 6268]"]]
   outL45 = Position 49  3  ;  outSig = [ExpectHoverText ["outer", "Bool"], mkR 46 0 46 5]
   innL48 = Position 52  5  ;  innSig = [ExpectHoverText ["inner", "Char"], mkR 49 2 49 7]
-  cccL17 = Position 17 11  ;  docLink = [ExpectHoverText ["[Documentation](file://"]]
+  cccL17 = Position 17 11  ;  docLink = [ExpectHoverText ["[Documentation](file:///"]]
 #if MIN_GHC_API_VERSION(8,6,0)
   imported = Position 56 13 ; importedSig = getDocUri "Foo.hs" >>= \foo -> return [ExpectHoverText ["foo", "Foo", "Haddock"], mkL foo 5 0 5 3]
   reexported = Position 55 14 ; reexportedSig = getDocUri "Bar.hs" >>= \bar -> return [ExpectHoverText ["Bar", "Bar", "Haddock"], mkL bar 3 0 3 14]


### PR DESCRIPTION
Part of the fix for haskell/haskell-language-server#247

Windows understands only file:/// but not file:// (at least it's true for VS Code)