### PR TITLE
Add a module Development.IDE

### DIFF
--- a/ghcide.cabal
+++ b/ghcide.cabal
@@ -117,6 +117,7 @@ library
     include-dirs:
         include
     exposed-modules:
+        Development.IDE
         Development.IDE.Compat
         Development.IDE.Core.Debouncer
         Development.IDE.Core.FileStore

--- a/src/Development/IDE.hs
+++ b/src/Development/IDE.hs
@@ -1,0 +1,46 @@
+module Development.IDE
+(
+    -- TODO It would be much nicer to enumerate all the exports
+    -- and organize them in sections
+    module X
+
+) where
+
+import Development.IDE.Core.RuleTypes as X
+import Development.IDE.Core.Rules as X
+  (GhcSessionIO(..)
+  ,getAtPoint
+  ,getDefinition
+  ,getParsedModule
+  ,getTypeDefinition
+  )
+import Development.IDE.Core.FileExists as X
+  (getFileExists)
+import Development.IDE.Core.FileStore as X
+  (getFileContents)
+import Development.IDE.Core.IdeConfiguration as X
+  (IdeConfiguration(..)
+  ,isWorkspaceFile)
+import Development.IDE.Core.OfInterest as X (getFilesOfInterest)
+import Development.IDE.Core.Service as X (runAction)
+import Development.IDE.Core.Shake as X
+  ( IdeState,
+    shakeExtras,
+    ShakeExtras,
+    IdeRule,
+    define,
+    GetModificationTime(GetModificationTime),
+    use, useNoFile, uses, useWithStaleFast, useWithStaleFast',
+    FastResult(..),
+    use_, useNoFile_, uses_,
+    ideLogger,
+    actionLogger,
+    IdeAction(..), runIdeAction
+  )
+import Development.IDE.GHC.Error as X
+import Development.IDE.GHC.Util as X
+import Development.IDE.Plugin as X
+import Development.IDE.Types.Diagnostics as X
+import Development.IDE.Types.Location as X
+import Development.IDE.Types.Logger as X
+import Development.Shake as X (Action, action, Rules, RuleResult)


### PR DESCRIPTION
A single module to reexport all the commonly used names to simplify the use of ghcide as a library
