### PR TITLE
Store the lsp client settings in shakeExtras and create a Rule to get them

### DIFF
--- a/.azure/linux-bench.yml
+++ b/.azure/linux-bench.yml
@@ -38,7 +38,8 @@ jobs:
     displayName: 'stack build --bench --only-dependencies'
   - bash: |
       export PATH=/opt/cabal/bin:$PATH
-      stack bench --ghc-options=-Werror  --stack-yaml=$STACK_YAML
+      # Retry to avoid fpcomplete servers timeouts
+      stack bench --ghc-options=-Werror --stack-yaml=$STACK_YAML || stack bench --ghc-options=-Werror --stack-yaml=$STACK_YAML  || stack bench --ghc-options=-Werror --stack-yaml=$STACK_YAML
     displayName: 'stack bench --ghc-options=-Werror'
   - bash: |
       cat bench-hist/results.csv

--- a/cabal.project
+++ b/cabal.project
@@ -1,5 +1,8 @@
 packages: .
 
+package ghcide
+  test-show-details: direct
+
 allow-newer:
 	active:base,
 	diagrams-contrib:base,

--- a/src/Development/IDE/Core/IdeConfiguration.hs
+++ b/src/Development/IDE/Core/IdeConfiguration.hs
@@ -2,6 +2,7 @@
 module Development.IDE.Core.IdeConfiguration
   ( IdeConfiguration(..)
   , registerIdeConfiguration
+  , getIdeConfiguration
   , parseConfiguration
   , parseWorkspaceFolder
   , isWorkspaceFile
@@ -61,9 +62,9 @@ modifyWorkspaceFolders ide f = modifyIdeConfiguration ide f'
   where f' (IdeConfiguration ws initOpts) = IdeConfiguration (f ws) initOpts
 
 modifyClientSettings
-  :: IdeState -> (Value -> Value) -> IO ()
+  :: IdeState -> (Maybe Value -> Maybe Value) -> IO ()
 modifyClientSettings ide f = modifyIdeConfiguration ide f'
-  where f' (IdeConfiguration ws clientSettings) = IdeConfiguration ws (f <$> clientSettings)
+  where f' (IdeConfiguration ws clientSettings) = IdeConfiguration ws (f clientSettings)
 
 modifyIdeConfiguration
   :: IdeState -> (IdeConfiguration -> IdeConfiguration) -> IO ()

--- a/src/Development/IDE/Core/IdeConfiguration.hs
+++ b/src/Development/IDE/Core/IdeConfiguration.hs
@@ -8,6 +8,7 @@ module Development.IDE.Core.IdeConfiguration
   , isWorkspaceFile
   , modifyWorkspaceFolders
   , modifyClientSettings
+  , getClientSettings
   )
 where
 
@@ -84,3 +85,6 @@ isWorkspaceFile file =
         any
           (\root -> toText root `isPrefixOf` toText (filePathToUri' file))
           workspaceFolders
+
+getClientSettings :: Action (Maybe Value)
+getClientSettings = clientSettings <$> getIdeConfiguration 

--- a/src/Development/IDE/Core/IdeConfiguration.hs
+++ b/src/Development/IDE/Core/IdeConfiguration.hs
@@ -87,4 +87,4 @@ isWorkspaceFile file =
           workspaceFolders
 
 getClientSettings :: Action (Maybe Value)
-getClientSettings = clientSettings <$> getIdeConfiguration 
+getClientSettings = clientSettings <$> getIdeConfiguration

--- a/src/Development/IDE/Core/IdeConfiguration.hs
+++ b/src/Development/IDE/Core/IdeConfiguration.hs
@@ -71,8 +71,7 @@ modifyIdeConfiguration
   :: IdeState -> (IdeConfiguration -> IdeConfiguration) -> IO ()
 modifyIdeConfiguration ide f = do
   IdeConfigurationVar var <- getIdeGlobalState ide
-  ideConfig <- readVar var
-  writeVar var (f ideConfig)
+  modifyVar_ var (pure . f)
 
 isWorkspaceFile :: NormalizedFilePath -> Action Bool
 isWorkspaceFile file =

--- a/src/Development/IDE/Core/RuleTypes.hs
+++ b/src/Development/IDE/Core/RuleTypes.hs
@@ -262,4 +262,4 @@ instance Hashable GetClientSettings
 instance NFData   GetClientSettings
 instance Binary   GetClientSettings
 
-type instance RuleResult GetClientSettings = Maybe Value
+type instance RuleResult GetClientSettings = Hashed (Maybe Value)

--- a/src/Development/IDE/Core/RuleTypes.hs
+++ b/src/Development/IDE/Core/RuleTypes.hs
@@ -12,6 +12,7 @@ module Development.IDE.Core.RuleTypes(
     ) where
 
 import           Control.DeepSeq
+import Data.Aeson.Types (Value)
 import Data.Binary
 import           Development.IDE.Import.DependencyInformation
 import Development.IDE.GHC.Compat
@@ -253,3 +254,11 @@ data GetModSummary = GetModSummary
 instance Hashable GetModSummary
 instance NFData   GetModSummary
 instance Binary   GetModSummary
+
+data GetClientSettings = GetClientSettings
+    deriving (Eq, Show, Typeable, Generic)
+instance Hashable GetClientSettings
+instance NFData   GetClientSettings
+instance Binary   GetClientSettings
+
+type instance RuleResult GetClientSettings = Maybe Value

--- a/src/Development/IDE/Core/RuleTypes.hs
+++ b/src/Development/IDE/Core/RuleTypes.hs
@@ -255,6 +255,7 @@ instance Hashable GetModSummary
 instance NFData   GetModSummary
 instance Binary   GetModSummary
 
+-- | Get the vscode client settings stored in the ide state
 data GetClientSettings = GetClientSettings
     deriving (Eq, Show, Typeable, Generic)
 instance Hashable GetClientSettings

--- a/src/Development/IDE/Core/Rules.hs
+++ b/src/Development/IDE/Core/Rules.hs
@@ -835,9 +835,10 @@ extractHiFileResult (Just tmr) =
     Just $! tmr_hiFileResult tmr
 
 getClientSettingsRule :: Rules ()
-getClientSettingsRule = defineNoFile $ \GetClientSettings -> do
+getClientSettingsRule = defineEarlyCutOffNoFile $ \GetClientSettings -> do
   alwaysRerun
-  clientSettings <$> getIdeConfiguration
+  settings <- clientSettings <$> getIdeConfiguration
+  return (BS.pack . show . hash $ settings, settings)
 
 -- | A rule that wires per-file rules together
 mainRule :: Rules ()

--- a/src/Development/IDE/Core/Rules.hs
+++ b/src/Development/IDE/Core/Rules.hs
@@ -12,7 +12,7 @@
 --
 module Development.IDE.Core.Rules(
     IdeState, GetDependencies(..), GetParsedModule(..), TransitiveDependencies(..),
-    Priority(..), GhcSessionIO(..),
+    Priority(..), GhcSessionIO(..), GetClientSettings(..),
     priorityTypeCheck,
     priorityGenerateCore,
     priorityFilesOfInterest,
@@ -73,6 +73,7 @@ import DynFlags (gopt_set, xopt)
 import GHC.Generics(Generic)
 
 import qualified Development.IDE.Spans.AtPoint as AtPoint
+import Development.IDE.Core.IdeConfiguration
 import Development.IDE.Core.Service
 import Development.IDE.Core.Shake
 import Development.Shake.Classes hiding (get, put)
@@ -833,6 +834,11 @@ extractHiFileResult (Just tmr) =
     -- Bang patterns are important to force the inner fields
     Just $! tmr_hiFileResult tmr
 
+getClientSettingsRule :: Rules ()
+getClientSettingsRule = defineNoFile $ \GetClientSettings -> do
+  alwaysRerun
+  clientSettings <$> getIdeConfiguration
+
 -- | A rule that wires per-file rules together
 mainRule :: Rules ()
 mainRule = do
@@ -852,6 +858,7 @@ mainRule = do
     isHiFileStableRule
     getModuleGraphRule
     knownFilesRule
+    getClientSettingsRule
 
 -- | Given the path to a module src file, this rule returns True if the
 -- corresponding `.hi` file is stable, that is, if it is newer

--- a/src/Development/IDE/Core/Shake.hs
+++ b/src/Development/IDE/Core/Shake.hs
@@ -569,8 +569,8 @@ shakeRestart IdeState{..} acts =
                       _ -> ""
               let msg = T.pack $ "Restarting build session (aborting the previous one took "
                               ++ showDuration stopTime ++ profile ++ ")"
-              logDebug (logger shakeExtras) $ msg
-              (eventer shakeExtras) (notifyLogMessage msg)
+              logDebug (logger shakeExtras) msg
+              eventer shakeExtras (notifyLogMessage msg)
         )
         -- It is crucial to be masked here, otherwise we can get killed
         -- between spawning the new thread and updating shakeSession.
@@ -581,7 +581,7 @@ shakeRestart IdeState{..} acts =
 notifyLogMessage :: T.Text -> LSP.FromServerMessage
 notifyLogMessage msg =
     LSP.NotLogMessage $ LSP.NotificationMessage "2.0" LSP.WindowLogMessage
-                      $ LSP.LogMessageParams LSP.MtLog $ msg
+                      $ LSP.LogMessageParams LSP.MtLog msg
 
 -- | Enqueue an action in the existing 'ShakeSession'.
 --   Returns a computation to block until the action is run, propagating exceptions.
@@ -625,7 +625,7 @@ newSession ShakeExtras{..} shakeDb acts = do
             let msg = T.pack $ "finish: " ++ actionName d
                             ++ " (took " ++ showDuration runTime ++ ")"
             liftIO $ do
-                logPriority logger (actionPriority d) $ msg
+                logPriority logger (actionPriority d) msg
                 eventer $ notifyLogMessage msg
 
         workRun restore = do
@@ -636,7 +636,7 @@ newSession ShakeExtras{..} shakeDb acts = do
                       Right _ -> "completed"
           let msg = T.pack $ "Finishing build session(" ++ res' ++ ")"
           return $ do
-              logDebug logger $ msg
+              logDebug logger msg
               eventer $ notifyLogMessage msg
 
     -- Do the work in a background thread

--- a/src/Development/IDE/LSP/LanguageServer.hs
+++ b/src/Development/IDE/LSP/LanguageServer.hs
@@ -204,7 +204,10 @@ initHandler
     -> IdeState
     -> InitializeParams
     -> IO ()
-initHandler _ ide params = registerIdeConfiguration (shakeExtras ide) (parseConfiguration params)
+initHandler _ ide params = do
+    let initConfig = parseConfiguration params
+    logInfo (ideLogger ide) $ T.pack $ "Registering ide configuration: " <> show initConfig
+    registerIdeConfiguration (shakeExtras ide) initConfig
 
 -- | Things that get sent to us, but we don't deal with.
 --   Set them to avoid a warning in VS Code output.

--- a/src/Development/IDE/LSP/Notifications.hs
+++ b/src/Development/IDE/LSP/Notifications.hs
@@ -97,4 +97,5 @@ setHandlersNotifications = PartialHandlers $ \WithMessage{..} x -> return x
             let msg = Text.pack $ show cfg
             logInfo (ideLogger ide) $ "Configuration changed: " <> msg
             modifyClientSettings ide (const $ Just cfg)
+            setSomethingModified ide
     }

--- a/src/Development/IDE/LSP/Notifications.hs
+++ b/src/Development/IDE/LSP/Notifications.hs
@@ -91,7 +91,7 @@ setHandlersNotifications = PartialHandlers $ \WithMessage{..} x -> return x
             modifyWorkspaceFolders ide
               $ add       (foldMap (S.singleton . parseWorkspaceFolder) (_added   events))
               . substract (foldMap (S.singleton . parseWorkspaceFolder) (_removed events))
-    
+
     ,LSP.didChangeConfigurationParamsHandler = withNotification (LSP.didChangeConfigurationParamsHandler x) $
         \_ ide (DidChangeConfigurationParams cfg) -> do
             let msg = Text.pack $ show cfg

--- a/src/Development/IDE/LSP/Notifications.hs
+++ b/src/Development/IDE/LSP/Notifications.hs
@@ -96,5 +96,5 @@ setHandlersNotifications = PartialHandlers $ \WithMessage{..} x -> return x
         \_ ide (DidChangeConfigurationParams cfg) -> do
             let msg = Text.pack $ show cfg
             logInfo (ideLogger ide) $ "Configuration changed: " <> msg
-            modifyClientSettings ide (const cfg)
+            modifyClientSettings ide (const $ Just cfg)
     }

--- a/src/Development/IDE/LSP/Notifications.hs
+++ b/src/Development/IDE/LSP/Notifications.hs
@@ -91,4 +91,10 @@ setHandlersNotifications = PartialHandlers $ \WithMessage{..} x -> return x
             modifyWorkspaceFolders ide
               $ add       (foldMap (S.singleton . parseWorkspaceFolder) (_added   events))
               . substract (foldMap (S.singleton . parseWorkspaceFolder) (_removed events))
+    
+    ,LSP.didChangeConfigurationParamsHandler = withNotification (LSP.didChangeConfigurationParamsHandler x) $
+        \_ ide (DidChangeConfigurationParams cfg) -> do
+            let msg = Text.pack $ show cfg
+            logInfo (ideLogger ide) $ "Configuration changed: " <> msg
+            modifyClientSettings ide (const cfg)
     }

--- a/test/exe/Main.hs
+++ b/test/exe/Main.hs
@@ -3297,7 +3297,7 @@ clientSettingsTest = testGroup "client settings handling"
 
         isMessagePresent expectedMsg actualMsgs = liftIO $
             assertBool ("\"" ++ expectedMsg ++ "\" is not present in: " ++ show actualMsgs)
-                       (any (expectedMsg `isSubsequenceOf`) (map show actualMsgs))
+                       (any ((expectedMsg `isSubsequenceOf`) . show) actualMsgs)
 ----------------------------------------------------------------------
 -- Utils
 ----------------------------------------------------------------------

--- a/test/exe/Main.hs
+++ b/test/exe/Main.hs
@@ -2253,7 +2253,7 @@ checkFileCompiles fp =
     expectNoMoreDiagnostics 0.5
 
 pluginSimpleTests :: TestTree
-pluginSimpleTests = 
+pluginSimpleTests =
   testSessionWait "simple plugin" $ do
     let content =
           T.unlines
@@ -2275,11 +2275,11 @@ pluginSimpleTests =
           )
       ]
 
-pluginParsedResultTests :: TestTree 
-pluginParsedResultTests = 
-  (`xfail84` "record-dot-preprocessor unsupported on 8.4") $ testSessionWait "parsedResultAction plugin" $ do 
-    let content = 
-          T.unlines 
+pluginParsedResultTests :: TestTree
+pluginParsedResultTests =
+  (`xfail84` "record-dot-preprocessor unsupported on 8.4") $ testSessionWait "parsedResultAction plugin" $ do
+    let content =
+          T.unlines
             [ "{-# LANGUAGE DuplicateRecordFields, TypeApplications, FlexibleContexts, DataKinds, MultiParamTypeClasses, TypeSynonymInstances, FlexibleInstances #-}"
             , "{-# OPTIONS_GHC -fplugin=RecordDotPreprocessor #-}"
             , "module Testing (Company(..), display) where"
@@ -2287,7 +2287,7 @@ pluginParsedResultTests =
             , "display :: Company -> String"
             , "display c = c.name"
             ]
-    _ <- createDoc "Testing.hs" "haskell" content 
+    _ <- createDoc "Testing.hs" "haskell" content
     expectNoMoreDiagnostics 1
 
 cppTests :: TestTree
@@ -3084,9 +3084,7 @@ ifaceErrorTest = testCase "iface-error-test-1" $ withoutStackEnv $ runWithExtraF
 
     -- Check that we wrote the interfaces for B when we saved
     lid <- sendRequest (CustomClientMethod "hidir") $ GetInterfaceFilesDir bPath
-    res <- skipManyTill (message :: Session WorkDoneProgressCreateRequest) $
-           skipManyTill (message :: Session WorkDoneProgressBeginNotification) $
-             responseForId lid
+    res <- skipManyTill anyMessage $ responseForId lid
     liftIO $ case res of
       ResponseMessage{_result=Right hidir} -> do
         hi_exists <- doesFileExist $ hidir </> "B.hi"


### PR DESCRIPTION
* The motivation is to expose the client settings in shake rules, concretely my goal is to enable or disable [hlint diagnostics](https://github.com/haskell/haskell-language-server/pull/166) using a client setting, changing diagnostics on the fly if the user change it in the editor
  * I hope being able to configure the rules (when parsing or typechecking for example?) using the client settings could be useful in general
*  The config is stored in the json raw format and updated using the `InitializeParams` and the `didChangeConfigurationParamsHandler` notification
  * The first one is empty using vscode, it notifies a configuration change when the lsp server is started. I guess other editors will use the first one (???). I assume both should update the client settings cause the `onInitialConfig` and `onConfigChange` callbacks returns the same type (it is a type param in ghcide)
* The client settings has an specific rule, which uses `alwaysRerun`, inspired in #688. There @pepeiborra advised it can degrade performance, but i guess there will be not much configuration changes.
* With this patch a Rule that depends on `GetClientSettings` (for example the hlint rule that produces hlint diagnostics) is rerun on a file modification or opening a new one. Ideally i would like to trigger it within the configuration change itself (maybe restarting the shake session?)

Sorry i am missing something obvious in the ghcide or shake concepts, this is my first pr touching their internals.