### PR TITLE
Include module path in progress message

### DIFF
--- a/session-loader/Development/IDE/Session.hs
+++ b/session-loader/Development/IDE/Session.hs
@@ -204,8 +204,8 @@ loadSession dir = do
            cradle <- maybe (loadImplicitCradle $ addTrailingPathSeparator dir) loadCradle hieYaml
            -- Display a user friendly progress message here: They probably don't know what a
            -- cradle is
-           let progMsg = "Setting up project " <> T.pack (takeBaseName (cradleRootDir cradle))
-
+           let progMsg = "Setting up " <> T.pack (takeBaseName (cradleRootDir cradle))
+                         <> " (for " <> T.pack cfp <> ")"
            eopts <- withIndefiniteProgress progMsg NotCancellable $
              cradleToOptsAndLibDir cradle cfp
 


### PR DESCRIPTION
We use a multi-project bios cradle at work, and currently the progress message is always the same "Setting up project fbcode", which isn't very helpful. This simple change will help at least determine what prompted the cradle call