### PR TITLE
CI: remove (internal) DA Slack notifications

### DIFF
--- a/.azure/linux-stack.yml
+++ b/.azure/linux-stack.yml
@@ -52,12 +52,3 @@ jobs:
       mkdir -p .azure-cache
       tar czf .azure-cache/stack-root.tar.gz -C $HOME .stack
     displayName: "Pack cache"
-  - bash: |
-      set -euo pipefail
-      MESSAGE=$(git log --pretty=format:%s -n1)
-      curl -XPOST \
-           -i \
-           -H 'Content-type: application/json' \
-           --data "{\"text\":\"<!here> *FAILED* $(Agent.JobName): <https://dev.azure.com/digitalasset/ghcide/_build/results?buildId=$(Build.BuildId)|$MESSAGE>\n\"}" \
-           $(Slack.URL)
-    condition: and(failed(), eq(variables['Build.SourceBranchName'], 'master'))

--- a/.azure/windows-stack.yml
+++ b/.azure/windows-stack.yml
@@ -68,12 +68,3 @@ jobs:
       tar -vczf .azure-cache/stack-root.tar.gz $(cygpath $STACK_ROOT)
       tar -vczf .azure-cache/stack-work.tar.gz .stack-work
     displayName: "Pack cache"
-  - bash: |
-      set -euo pipefail
-      MESSAGE=$(git log --pretty=format:%s -n1)
-      curl -XPOST \
-           -i \
-           -H 'Content-type: application/json' \
-           --data "{\"text\":\"<!here> *FAILED* $(Agent.JobName): <https://dev.azure.com/digitalasset/ghcide/_build/results?buildId=$(Build.BuildId)|$MESSAGE>\n\"}" \
-           $(Slack.URL)
-    condition: and(failed(), eq(variables['Build.SourceBranchName'], 'master'))


### PR DESCRIPTION
With the repo now officially transferred from Digital Asset's control to the open-source Haskell organization, there is no good reason for master builds to ping DA anymore. This (the corresponding Slack token "secret") is also the only piece of non-open-source configuration in the existing build process, so it needs to be removed before the CI can be transferred.