### PR TITLE
Don't typecheck parents when there are no known files

### DIFF
--- a/src/Development/IDE/Core/FileStore.hs
+++ b/src/Development/IDE/Core/FileStore.hs
@@ -230,13 +230,15 @@ typecheckParents state nfp = void $ shakeEnqueue state parents
 
 typecheckParentsAction :: NormalizedFilePath -> Action ()
 typecheckParentsAction nfp = do
-    revs <- reverseDependencies nfp <$> useNoFile_ GetModuleGraph
-    logger <- logger <$> getShakeExtras
-    let log = L.logInfo logger . T.pack
-    liftIO $ do
-      (log $ "Typechecking reverse dependencies for" ++ show nfp ++ ": " ++ show revs)
-        `catch` \(e :: SomeException) -> log (show e)
-    () <$ uses GetModIface revs
+    fs <- useNoFile_ GetKnownFiles
+    unless (null fs) $ do
+      revs <- reverseDependencies nfp <$> useNoFile_ GetModuleGraph
+      logger <- logger <$> getShakeExtras
+      let log = L.logInfo logger . T.pack
+      liftIO $ do
+        (log $ "Typechecking reverse dependencies for" ++ show nfp ++ ": " ++ show revs)
+          `catch` \(e :: SomeException) -> log (show e)
+      () <$ uses GetModIface revs
 
 -- | Note that some buffer somewhere has been modified, but don't say what.
 --   Only valid if the virtual file system was initialised by LSP, as that


### PR DESCRIPTION
Should fix https://github.com/haskell/haskell-language-server/issues/181 in most cases
