### PR TITLE
Increase timeout of azure windows job

### DIFF
--- a/.azure/windows-stack.yml
+++ b/.azure/windows-stack.yml
@@ -1,6 +1,6 @@
 jobs:
 - job: ghcide_stack_windows
-  timeoutInMinutes: 60
+  timeoutInMinutes: 120
   pool:
     vmImage: 'windows-2019'
   strategy:


### PR DESCRIPTION
* As @wz1000 has noted, the windows job is failing lately due to the actual 60 minutes timeout, increased to 120