### PR TITLE
Allow for implicit (single file) cradles

### DIFF
--- a/src/Development/IDE/Core/Rules.hs
+++ b/src/Development/IDE/Core/Rules.hs
@@ -322,7 +322,8 @@ getLocatedImportsRule =
         let dflags = addRelativeImport file (moduleName $ ms_mod ms) $ hsc_dflags env
         opt <- getIdeOptions
         let getTargetExists nfp
-                | HashSet.null targets || nfp `HashSet.member` targets = getFileExists nfp
+                | HashSet.size targets <= 1 || nfp `HashSet.member` targets
+                = getFileExists nfp
                 | otherwise = return False
         (diags, imports') <- fmap unzip $ forM imports $ \(isSource, (mbPkgName, modName)) -> do
             diagOrImp <- locateModule dflags import_dirs (optExtensions opt) getTargetExists modName mbPkgName isSource


### PR DESCRIPTION
I recently fixed a bug in the logic that figures out the path to an imported module arising when modules A B belong to different cradles C_A and C_B (https://github.com/wz1000/ghcide/pull/10/files). That fix assumes that the cradles list all the targets, an assumption that we already make in many other places, and apparently introduces a regression in implicit cradle handling.

This fix is intended to partially address that regression