### PR TITLE
Fix documentation (or source) link when html file is less specific than module

### DIFF
--- a/src/Development/IDE/Spans/Documentation.hs
+++ b/src/Development/IDE/Spans/Documentation.hs
@@ -171,7 +171,7 @@ lookupSrcHtmlForModule =
 lookupHtmlForModule :: (FilePath -> FilePath -> FilePath) -> DynFlags -> Module -> IO (Maybe FilePath)
 lookupHtmlForModule mkDocPath df m = do
   -- try all directories
-  let mfs = fmap (concat . fmap go) (lookupHtmls df ui)
+  let mfs = fmap (concatMap go) (lookupHtmls df ui)
   htmls <- filterM doesFileExist (concat . maybeToList $ mfs)
   return $ listToMaybe htmls
   where

--- a/src/Development/IDE/Spans/Documentation.hs
+++ b/src/Development/IDE/Spans/Documentation.hs
@@ -175,14 +175,14 @@ lookupHtmlForModule mkDocPath df m = do
   htmls <- filterM doesFileExist (concat . maybeToList $ mfs)
   return $ listToMaybe htmls
   where
-    -- The file might use "." or "-" as separator
-    go pkgDocDir = [mkDocPath pkgDocDir mn | mn <- mns]
+    go pkgDocDir = map (mkDocPath pkgDocDir) mns
     ui = moduleUnitId m
     -- try to locate html file from most to least specific name e.g.
     --  first Language.Haskell.LSP.Types.Uri.html and Language-Haskell-LSP-Types-Uri.html
     --  then Language.Haskell.LSP.Types.html and Language-Haskell-LSP-Types.html etc.
     mns = do
       chunks <- (reverse . drop 1 . inits . splitOn ".") $ (moduleNameString . moduleName) m
+      -- The file might use "." or "-" as separator
       map (`intercalate` chunks) [".", "-"]
 
 lookupHtmls :: DynFlags -> UnitId -> Maybe [FilePath]

--- a/src/Development/IDE/Spans/Documentation.hs
+++ b/src/Development/IDE/Spans/Documentation.hs
@@ -171,7 +171,7 @@ lookupSrcHtmlForModule =
 lookupHtmlForModule :: (FilePath -> FilePath -> FilePath) -> DynFlags -> Module -> IO (Maybe FilePath)
 lookupHtmlForModule mkDocPath df m = do
   -- try all directories
-  let mfs =  fmap concat $ (fmap . fmap) go (lookupHtmls df ui)
+  let mfs = fmap (concat . fmap go) (lookupHtmls df ui)
   htmls <- filterM doesFileExist (concat . maybeToList $ mfs)
   return $ listToMaybe htmls
   where
@@ -181,7 +181,7 @@ lookupHtmlForModule mkDocPath df m = do
     --  first Language.Haskell.LSP.Types.Uri.html and Language-Haskell-LSP-Types-Uri.html
     --  then Language.Haskell.LSP.Types.html and Language-Haskell-LSP-Types.html etc.
     mns = do
-      chunks <- (reverse . drop 1 . inits . splitOn ".") $ (moduleNameString . moduleName) m
+      chunks <- (reverse . drop1 . inits . splitOn ".") $ (moduleNameString . moduleName) m
       -- The file might use "." or "-" as separator
       map (`intercalate` chunks) [".", "-"]
 

--- a/src/Development/IDE/Spans/Documentation.hs
+++ b/src/Development/IDE/Spans/Documentation.hs
@@ -176,14 +176,14 @@ lookupHtmlForModule mkDocPath df m = do
   return $ listToMaybe htmls
   where
     -- The file might use "." or "-" as separator
-    go pkgDocDir = [mkDocPath pkgDocDir mn | mn <- mndots ++ mndashes]
+    go pkgDocDir = [mkDocPath pkgDocDir mn | mn <- mns]
     ui = moduleUnitId m
     -- try to locate html file from most to least specific name e.g.
-    --  first Language.Haskell.LSP.Types.Uri.html 
-    --  then Language.Haskell.LSP.Types.html 
-    --  then Language.Haskell.LSP.html etc.
-    mndots = (map (intercalate ".") . reverse . drop 1 . inits . splitOn ".") $ (moduleNameString . moduleName) m
-    mndashes = (fmap . fmap) (\x -> if x == '.' then '-' else x) mndots
+    --  first Language.Haskell.LSP.Types.Uri.html and Language-Haskell-LSP-Types-Uri.html
+    --  then Language.Haskell.LSP.Types.html and Language-Haskell-LSP-Types.html etc.
+    mns = do
+      chunks <- (reverse . drop 1 . inits . splitOn ".") $ (moduleNameString . moduleName) m
+      map (`intercalate` chunks) [".", "-"]
 
 lookupHtmls :: DynFlags -> UnitId -> Maybe [FilePath]
 lookupHtmls df ui = haddockHTMLs <$> lookupPackage df ui


### PR DESCRIPTION
Below is an example when documentation is available but wasn't located because file name is less specific than module. This PR fixes it


**Documentation:**
Note the difference in doc file name and module name.

![image](https://user-images.githubusercontent.com/5116838/92303285-85c48280-efc7-11ea-80ec-35a9c167ce18.png)

**Source:**
In this case both src and module name are the same.

![image](https://user-images.githubusercontent.com/5116838/92303333-eb187380-efc7-11ea-96d4-e7d191e7ca29.png)


**Other notes:**

* Also all directories attempted (not sure if it can possibly be more than one directory but original code is trying only first anyway)
* Just in case I'm on Windows (10)
* I'm experiencing more troubles with docs/sources on Windows (docs for most libs reported to be at $topdir/../ which doesn't work on Windows) but let's tackle one thing at a time.
* using stack

