### PR TITLE
Fully asynchronous request handling

### DIFF
--- a/exe/Main.hs
+++ b/exe/Main.hs
@@ -81,7 +81,8 @@ main = do
     dir <- IO.getCurrentDirectory
     command <- makeLspCommandId "typesignature.add"
 
-    let plugins = Completions.plugin <> CodeAction.plugin <> Test.plugin
+    let plugins = Completions.plugin <> CodeAction.plugin
+            <> if argsTesting then Test.plugin else mempty
         onInitialConfiguration :: InitializeRequest -> Either T.Text LspConfig
         onInitialConfiguration x = case x ^. params . initializationOptions of
           Nothing -> Right defaultLspConfig

--- a/exe/Main.hs
+++ b/exe/Main.hs
@@ -30,6 +30,7 @@ import Development.IDE.Types.Logger
 import Development.IDE.Plugin
 import Development.IDE.Plugin.Completions as Completions
 import Development.IDE.Plugin.CodeAction as CodeAction
+import Development.IDE.Plugin.Test as Test
 import Development.IDE.Session
 import qualified Language.Haskell.LSP.Core as LSP
 import Language.Haskell.LSP.Messages
@@ -80,7 +81,7 @@ main = do
     dir <- IO.getCurrentDirectory
     command <- makeLspCommandId "typesignature.add"
 
-    let plugins = Completions.plugin <> CodeAction.plugin
+    let plugins = Completions.plugin <> CodeAction.plugin <> Test.plugin
         onInitialConfiguration :: InitializeRequest -> Either T.Text LspConfig
         onInitialConfiguration x = case x ^. params . initializationOptions of
           Nothing -> Right defaultLspConfig

--- a/ghcide.cabal
+++ b/ghcide.cabal
@@ -147,6 +147,7 @@ library
         Development.IDE.Plugin
         Development.IDE.Plugin.Completions
         Development.IDE.Plugin.CodeAction
+        Development.IDE.Plugin.Test
 
     -- Unfortunately, we cannot use loadSession with ghc-lib since hie-bios uses
     -- the real GHC library and the types are incompatible. Furthermore, when

--- a/ghcide.cabal
+++ b/ghcide.cabal
@@ -338,7 +338,7 @@ test-suite ghcide-tests
         haskell-lsp-types,
         network-uri,
         lens,
-        lsp-test >= 0.11.0.1 && < 0.12,
+        lsp-test >= 0.11.0.5 && < 0.12,
         optparse-applicative,
         process,
         QuickCheck,

--- a/src/Development/IDE/LSP/LanguageServer.hs
+++ b/src/Development/IDE/LSP/LanguageServer.hs
@@ -71,6 +71,8 @@ runLanguageServer options userHandlers onInitialConfig onConfigChange getIdeStat
     -- This should not happen but if it does, we will make sure that the whole server
     -- dies and can be restarted instead of losing threads silently.
     clientMsgBarrier <- newBarrier
+    -- Forcefully exit
+    let exit = signalBarrier clientMsgBarrier ()
 
     -- The set of requests ids that we have received but not finished processing
     pendingRequests <- newTVarIO Set.empty
@@ -107,7 +109,8 @@ runLanguageServer options userHandlers onInitialConfig onConfigChange getIdeStat
             setHandlersOutline <>
             userHandlers <>
             setHandlersNotifications <> -- absolutely critical, join them with user notifications
-            cancelHandler cancelRequest
+            cancelHandler cancelRequest <>
+            exitHandler exit
             -- Cancel requests are special since they need to be handled
             -- out of order to be useful. Existing handlers are run afterwards.
     handlers <- parts WithMessage{withResponse, withNotification, withResponseAndRequest, withInitialize} def
@@ -115,7 +118,7 @@ runLanguageServer options userHandlers onInitialConfig onConfigChange getIdeStat
     let initializeCallbacks = LSP.InitializeCallbacks
             { LSP.onInitialConfiguration = onInitialConfig
             , LSP.onConfigurationChange = onConfigChange
-            , LSP.onStartup = handleInit (signalBarrier clientMsgBarrier ()) clearReqId waitForCancel clientMsgChan
+            , LSP.onStartup = handleInit exit clearReqId waitForCancel clientMsgChan
             }
 
     void $ waitAnyCancel =<< traverse async
@@ -137,7 +140,8 @@ runLanguageServer options userHandlers onInitialConfig onConfigChange getIdeStat
 
             _ <- flip forkFinally (const exitClientMsg) $ forever $ do
                 msg <- readChan clientMsgChan
-                case msg of
+                -- dispatch the work to a new thread
+                void $ async $ case msg of
                     Notification x@NotificationMessage{_params} act -> do
                         catch (act lspFuncs ide _params) $ \(e :: SomeException) ->
                             logError (ideLogger ide) $ T.pack $
@@ -217,6 +221,9 @@ cancelHandler cancelRequest = PartialHandlers $ \_ x -> return x
             whenJust (LSP.cancelNotificationHandler x) ($ msg)
     }
 
+exitHandler :: IO () -> PartialHandlers c
+exitHandler exit = PartialHandlers $ \_ x -> return x
+    {LSP.exitNotificationHandler = Just $ \_ -> exit}
 
 -- | A message that we need to deal with - the pieces are split up with existentials to gain additional type safety
 --   and defer precise processing until later (allows us to keep at a higher level of abstraction slightly longer)

--- a/src/Development/IDE/LSP/LanguageServer.hs
+++ b/src/Development/IDE/LSP/LanguageServer.hs
@@ -223,7 +223,7 @@ cancelHandler cancelRequest = PartialHandlers $ \_ x -> return x
 
 exitHandler :: IO () -> PartialHandlers c
 exitHandler exit = PartialHandlers $ \_ x -> return x
-    {LSP.exitNotificationHandler = Just $ \_ -> exit}
+    {LSP.exitNotificationHandler = Just $ const exit}
 
 -- | A message that we need to deal with - the pieces are split up with existentials to gain additional type safety
 --   and defer precise processing until later (allows us to keep at a higher level of abstraction slightly longer)

--- a/src/Development/IDE/Plugin/Test.hs
+++ b/src/Development/IDE/Plugin/Test.hs
@@ -41,7 +41,7 @@ plugin = Plugin {
         = requestHandler lsp ide customReq
         | otherwise
         = return $ Left
-        $ ResponseError InvalidRequest ("Cannot parse request") Nothing
+        $ ResponseError InvalidRequest "Cannot parse request" Nothing
 
 requestHandler :: LspFuncs c
                 -> IdeState

--- a/src/Development/IDE/Plugin/Test.hs
+++ b/src/Development/IDE/Plugin/Test.hs
@@ -1,0 +1,64 @@
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DerivingStrategies #-}
+-- | A plugin that adds custom messages for use in tests
+module Development.IDE.Plugin.Test (TestRequest(..), plugin) where
+
+import Control.Monad.STM
+import Data.Aeson
+import Data.Aeson.Types
+import Development.IDE.Core.Service
+import Development.IDE.Core.Shake
+import Development.IDE.GHC.Compat
+import Development.IDE.GHC.Util (HscEnvEq(hscEnv))
+import Development.IDE.LSP.Server
+import Development.IDE.Plugin
+import Development.IDE.Types.Action
+import GHC.Generics (Generic)
+import GhcPlugins (HscEnv(hsc_dflags))
+import Language.Haskell.LSP.Core
+import Language.Haskell.LSP.Messages
+import Language.Haskell.LSP.Types
+import System.Time.Extra
+import Development.IDE.Core.RuleTypes
+
+data TestRequest
+    = BlockSeconds Seconds           -- ^ :: Null
+    | GetInterfaceFilesDir FilePath  -- ^ :: String
+    | GetShakeSessionQueueCount      -- ^ :: Number
+    deriving Generic
+    deriving anyclass (FromJSON, ToJSON)
+
+plugin :: Plugin c
+plugin = Plugin {
+    pluginRules = return (),
+    pluginHandler = PartialHandlers $ \WithMessage{..} x -> return x {
+        customRequestHandler = withResponse RspCustomServer requestHandler'
+    }
+}
+  where
+      requestHandler' lsp ide req
+        | Just customReq <- parseMaybe parseJSON req
+        = requestHandler lsp ide customReq
+        | otherwise
+        = return $ Left
+        $ ResponseError InvalidRequest ("Cannot parse request") Nothing
+
+requestHandler :: LspFuncs c
+                -> IdeState
+                -> TestRequest
+                -> IO (Either ResponseError Value)
+requestHandler lsp _ (BlockSeconds secs) = do
+    sendFunc lsp $ NotCustomServer $
+        NotificationMessage "2.0" (CustomServerMethod "ghcide/blocking/request") $
+        toJSON secs
+    sleep secs
+    return (Right Null)
+requestHandler _ s (GetInterfaceFilesDir fp) = do
+    let nfp = toNormalizedFilePath fp
+    sess <- runAction "Test - GhcSession" s $ use_ GhcSession nfp
+    let hiPath = hiDir $ hsc_dflags $ hscEnv sess
+    return $ Right (toJSON hiPath)
+requestHandler _ s GetShakeSessionQueueCount = do
+    n <- atomically $ countQueue $ actionQueue $ shakeExtras s
+    return $ Right (toJSON n)
+

--- a/src/Development/IDE/Types/Action.hs
+++ b/src/Development/IDE/Types/Action.hs
@@ -7,7 +7,7 @@ module Development.IDE.Types.Action
     popQueue,
     doneQueue,
     peekInProgress,
-  abortQueue)
+  abortQueue,countQueue)
 where
 
 import           Control.Concurrent.STM
@@ -17,6 +17,7 @@ import qualified Data.HashSet                 as Set
 import           Data.Unique                  (Unique)
 import           Development.IDE.Types.Logger
 import           Development.Shake            (Action)
+import           Numeric.Natural
 
 data DelayedAction a = DelayedAction
   { uniqueID       :: Maybe Unique,
@@ -75,6 +76,13 @@ abortQueue x ActionQueue {..} = do
 doneQueue :: DelayedActionInternal -> ActionQueue -> STM ()
 doneQueue x ActionQueue {..} = do
   modifyTVar inProgress (Set.delete x)
+
+countQueue :: ActionQueue -> STM Natural
+countQueue ActionQueue{..} = do
+    backlog <- flushTQueue newActions
+    mapM_ (writeTQueue newActions) backlog
+    m <- Set.size <$> readTVar inProgress
+    return $ fromIntegral $ length backlog + m
 
 peekInProgress :: ActionQueue -> STM [DelayedActionInternal]
 peekInProgress ActionQueue {..} = Set.toList <$> readTVar inProgress

--- a/stack-ghc-lib.yaml
+++ b/stack-ghc-lib.yaml
@@ -4,7 +4,7 @@ packages:
 extra-deps:
 - haskell-lsp-0.22.0.0
 - haskell-lsp-types-0.22.0.0
-- lsp-test-0.11.0.2
+- lsp-test-0.11.0.5
 - extra-1.7.2
 - hie-bios-0.6.1
 - ghc-lib-parser-8.8.1

--- a/stack.yaml
+++ b/stack.yaml
@@ -4,7 +4,7 @@ packages:
 extra-deps:
 - haskell-lsp-0.22.0.0
 - haskell-lsp-types-0.22.0.0
-- lsp-test-0.11.0.2
+- lsp-test-0.11.0.5
 - hie-bios-0.6.1
 - fuzzy-0.1.0.0
 - regex-pcre-builtin-0.95.1.1.8.43

--- a/stack810.yaml
+++ b/stack810.yaml
@@ -5,7 +5,7 @@ packages:
 extra-deps:
 - haskell-lsp-0.22.0.0
 - haskell-lsp-types-0.22.0.0
-- lsp-test-0.11.0.2
+- lsp-test-0.11.0.5
 - ghc-check-0.5.0.1
 - hie-bios-0.6.1
 

--- a/stack84.yaml
+++ b/stack84.yaml
@@ -7,7 +7,7 @@ extra-deps:
 - base-orphans-0.8.2
 - haskell-lsp-0.22.0.0
 - haskell-lsp-types-0.22.0.0
-- lsp-test-0.11.0.2
+- lsp-test-0.11.0.5
 - rope-utf16-splay-0.3.1.0
 - filepattern-0.1.1
 - js-dgtable-0.5.2

--- a/stack88.yaml
+++ b/stack88.yaml
@@ -4,7 +4,7 @@ packages:
 extra-deps:
 - haskell-lsp-0.22.0.0
 - haskell-lsp-types-0.22.0.0
-- lsp-test-0.11.0.2
+- lsp-test-0.11.0.5
 - ghc-check-0.5.0.1
 - hie-bios-0.6.1
 - extra-1.7.2

--- a/test/src/Development/IDE/Test.hs
+++ b/test/src/Development/IDE/Test.hs
@@ -70,9 +70,9 @@ expectNoMoreDiagnostics timeout = do
             "Got unexpected diagnostics for " <> show fileUri <>
             " got " <> show actual
     handleCustomMethodResponse =
-        -- the CustomClientMethod triggers a log message about ignoring it
+        -- the CustomClientMethod triggers a RspCustomServer
         -- handle that and then exit
-        void (LspTest.message :: Session LogMessageNotification)
+        void (LspTest.message :: Session CustomResponse)
     ignoreOthers = void anyMessage >> handleMessages
 
 expectDiagnostics :: [(FilePath, [(DiagnosticSeverity, Cursor, T.Text)])] -> Session ()


### PR DESCRIPTION
#727 made the Shake queue able to concurrently handle more than one rule, but ghcide still handled LSP requests sequentially. This change makes the LSP handler multi-threaded, so now ghcide no longer blocks while e.g. computing an expensive code lens.

This change also adds a custom request protocol for testing, which can be generally useful. For instance, tests can now query the location of the interface files cache dir which will be useful for testing #760

Reviewers - things to watch for:

- New space leaks
- New race conditions

To do:

- [ ] run benchmarks