### PR TITLE
Fix bug in exports map

### DIFF
--- a/session-loader/Development/IDE/Session.hs
+++ b/session-loader/Development/IDE/Session.hs
@@ -64,6 +64,7 @@ import Linker
 import Module
 import NameCache
 import Packages
+import Control.Exception (evaluate)
 
 -- | Given a root directory, return a Shake 'Action' which setups an
 -- 'IdeGhcSession' given a file.
@@ -312,7 +313,7 @@ loadSession dir = do
             -- update xports map
             extras <- getShakeExtras
             let !exportsMap' = createExportsMap $ mapMaybe (fmap hirModIface) modIfaces
-            liftIO $ modifyVar_ (exportsMap extras) $ return . (exportsMap' <>)
+            liftIO $ modifyVar_ (exportsMap extras) $ evaluate . (exportsMap' <>)
       pure opts
 
 -- | Run the specific cradle on a specific FilePath via hie-bios.

--- a/src/Development/IDE/Core/OfInterest.hs
+++ b/src/Development/IDE/Core/OfInterest.hs
@@ -99,6 +99,6 @@ kick = mkDelayedAction "kick" Debug $ do
     ShakeExtras{exportsMap} <- getShakeExtras
     let modIfaces = mapMaybe (fmap (hm_iface . tmrModInfo)) results
         !exportsMap' = createExportsMap modIfaces
-    liftIO $ modifyVar_ exportsMap $ return . (exportsMap' <>)
+    liftIO $ modifyVar_ exportsMap $ evaluate . (exportsMap' <>)
 
     liftIO $ progressUpdate KickCompleted

--- a/src/Development/IDE/Core/Shake.hs
+++ b/src/Development/IDE/Core/Shake.hs
@@ -413,7 +413,7 @@ shakeOpen getLspId eventer withProgress withIndefiniteProgress logger debouncer
         progressAsync <- async $
             when reportProgress $
                 progressThread mostRecentProgressEvent inProgress
-        exportsMap <- newVar HMap.empty
+        exportsMap <- newVar mempty
 
         actionQueue <- newQueue
 


### PR DESCRIPTION
It was appending lists of identifiers without pruning duplicates

Fixes #771 

<img width="819" alt="image" src="https://user-images.githubusercontent.com/26626/92326410-d8468300-f049-11ea-9b86-1eed2b7ef14b.png">

```
pepeiborra@pepeiborra-mbp w1 % column -t -s , bench-hist/results.csv
version    name                         success   samples   startup              setup                experiment           maxResidency
upstream   hover                        True      100       10.822233228         0.0                  2.436788999          582MB
upstream   edit                         True      100       9.478771113          0.0                  35.664150921         600MB
upstream   getDefinition                True      100       9.838020262          0.0                  2.5956575830000004   587MB
upstream   hover after edit             True      100       11.241869796000001   0.0                  5.150880557000001    566MB
upstream   completions after edit       True      100       10.113484234000001   0.0                  10.774867441000001   472MB
upstream   code actions                 True      100       10.635542301000001   4.162216031          0.527846514          552MB
upstream   code actions after edit      True      100       10.098725835         0.0                  25.293623039         545MB
upstream   documentSymbols after edit   True      100       16.169403093         0.0                  5.21765379           276MB
HEAD       hover                        True      100       9.445237065          0.0                  1.800860836          223MB
HEAD       edit                         True      100       9.710649867          0.0                  33.898333637         204MB
HEAD       getDefinition                True      100       9.380904548          0.0                  1.9576130440000001   222MB
HEAD       hover after edit             True      100       9.768509064          0.0                  4.9657159680000005   191MB
HEAD       completions after edit       True      100       9.609953897          0.0                  9.033533009000001    223MB
HEAD       code actions                 True      100       9.570470244000001    2.6726778230000003   1.4915889900000001   238MB
HEAD       code actions after edit      True      100       9.359972777000001    0.0                  21.629622857         237MB
HEAD       documentSymbols after edit   True      100       9.768980766          0.0                  4.321581539          182MB
```