### PR TITLE
Import paths are relative to cradle

### DIFF
--- a/.azure/linux-stack.yml
+++ b/.azure/linux-stack.yml
@@ -45,7 +45,7 @@ jobs:
     displayName: 'stack build --only-dependencies'
   - bash: |
       export PATH=/opt/cabal/bin:$PATH
-      stack test --ghc-options=-Werror  --stack-yaml=$STACK_YAML || stack test --ghc-options=-Werror --stack-yaml=$STACK_YAML|| LSP_TEST_LOG_MESSAGES=true LSP_TEST_LOG_STDERR=true stack test --ghc-options=-Werror --stack-yaml=$STACK_YAML
+      stack test --ghc-options=-Werror  --stack-yaml=$STACK_YAML || stack test --ghc-options=-Werror --stack-yaml=$STACK_YAML|| LSP_TEST_LOG_COLOR=0 LSP_TEST_LOG_MESSAGES=true LSP_TEST_LOG_STDERR=true stack test --ghc-options=-Werror --stack-yaml=$STACK_YAML
     # ghcide stack tests are flaky, see https://github.com/digital-asset/daml/issues/2606.
     displayName: 'stack test --ghc-options=-Werror'
   - bash: |

--- a/.azure/linux-stack.yml
+++ b/.azure/linux-stack.yml
@@ -45,7 +45,7 @@ jobs:
     displayName: 'stack build --only-dependencies'
   - bash: |
       export PATH=/opt/cabal/bin:$PATH
-      stack test --ghc-options=-Werror  --stack-yaml=$STACK_YAML || stack test --ghc-options=-Werror --stack-yaml=$STACK_YAML|| stack test --ghc-options=-Werror --stack-yaml=$STACK_YAML
+      stack test --ghc-options=-Werror  --stack-yaml=$STACK_YAML || stack test --ghc-options=-Werror --stack-yaml=$STACK_YAML|| LSP_TEST_LOG_MESSAGES=true LSP_TEST_LOG_STDERR=true stack test --ghc-options=-Werror --stack-yaml=$STACK_YAML
     # ghcide stack tests are flaky, see https://github.com/digital-asset/daml/issues/2606.
     displayName: 'stack test --ghc-options=-Werror'
   - bash: |

--- a/session-loader/Development/IDE/Session.hs
+++ b/session-loader/Development/IDE/Session.hs
@@ -300,13 +300,13 @@ loadSession dir = do
         return (fmap snd as, wait as)
       unless (null cs) $ do
         cfps' <- liftIO $ filterM (IO.doesFileExist . fromNormalizedFilePath) cs
+        -- populate the knownFilesVar with all the
+        -- files in the project so that `knownFiles` can learn about them and
+        -- we can generate a complete module graph
         liftIO $ modifyVar_ knownFilesVar $ traverseHashed $ \known -> do
             evaluate $ HashSet.union known (HashSet.fromList cfps')
         -- Typecheck all files in the project on startup
         void $ shakeEnqueue extras $ mkDelayedAction "InitialLoad" Debug $ void $ do
-          -- populate the knownFilesVar with all the
-          -- files in the project so that `knownFiles` can learn about them and
-          -- we can generate a complete module graph
           when checkProject $ do
             mmt <- uses GetModificationTime cfps'
             let cs_exist = catMaybes (zipWith (<$) cfps' mmt)

--- a/session-loader/Development/IDE/Session.hs
+++ b/session-loader/Development/IDE/Session.hs
@@ -225,9 +225,11 @@ loadSession dir = do
         -- populate the knownFilesVar with all the
         -- files in the project so that `knownFiles` can learn about them and
         -- we can generate a complete module graph
+          knownTargets <- filterM (IO.doesFileExist . fromNormalizedFilePath) resultCachedTargets
           modifyVar_ knownFilesVar $ traverseHashed $ \known -> do
-            let known' = HashSet.union known (HashSet.fromList resultCachedTargets)
-            when (known /= known') $ logDebug logger $ "Known files updated: " <> T.pack(show $ map fromNormalizedFilePath $ HashSet.toList known')
+            let known' = HashSet.union known $ HashSet.fromList knownTargets
+            when (known /= known') $
+                logDebug logger $ "Known files updated: " <> T.pack(show $ map fromNormalizedFilePath $ HashSet.toList known')
             evaluate known'
 
           -- Invalidate all the existing GhcSession build nodes by restarting the Shake session

--- a/session-loader/Development/IDE/Session.hs
+++ b/session-loader/Development/IDE/Session.hs
@@ -387,9 +387,7 @@ newComponentCache logger cradlePath hsc_env uids ci = do
     let hscEnv' = hsc_env { hsc_dflags = df
                           , hsc_IC = (hsc_IC hsc_env) { ic_dflags = df } }
 
-    let newFunc = case cradlePath of
-            Just p -> newHscEnvEq p
-            Nothing -> newHscEnvEqPreserveImportPaths
+    let newFunc = maybe newHscEnvEqPreserveImportPaths newHscEnvEq cradlePath
     henv <- newFunc hscEnv' uids
     let res = (([], Just henv), componentDependencyInfo ci)
     logDebug logger ("New Component Cache HscEnvEq: " <> T.pack (show res))

--- a/src/Development/IDE/Core/Compile.hs
+++ b/src/Development/IDE/Core/Compile.hs
@@ -15,6 +15,7 @@ module Development.IDE.Core.Compile
   , parseHeader
   , typecheckModule
   , computePackageDeps
+  , addRelativeImport
   , mkTcModuleResult
   , generateByteCode
   , generateAndWriteHieFile
@@ -250,6 +251,10 @@ hideDiag :: DynFlags -> (WarnReason, FileDiagnostic) -> (WarnReason, FileDiagnos
 hideDiag originalFlags (Reason warning, (nfp, _sh, fd))
   | not (wopt warning originalFlags) = (Reason warning, (nfp, HideDiag, fd))
 hideDiag _originalFlags t = t
+
+addRelativeImport :: NormalizedFilePath -> ModuleName -> DynFlags -> DynFlags
+addRelativeImport fp modu dflags = dflags
+    {importPaths = nubOrd $ maybeToList (moduleImportPath fp modu) ++ importPaths dflags}
 
 mkTcModuleResult
     :: GhcMonad m

--- a/src/Development/IDE/Core/Compile.hs
+++ b/src/Development/IDE/Core/Compile.hs
@@ -15,7 +15,6 @@ module Development.IDE.Core.Compile
   , parseHeader
   , typecheckModule
   , computePackageDeps
-  , addRelativeImport
   , mkTcModuleResult
   , generateByteCode
   , generateAndWriteHieFile
@@ -251,10 +250,6 @@ hideDiag :: DynFlags -> (WarnReason, FileDiagnostic) -> (WarnReason, FileDiagnos
 hideDiag originalFlags (Reason warning, (nfp, _sh, fd))
   | not (wopt warning originalFlags) = (Reason warning, (nfp, HideDiag, fd))
 hideDiag _originalFlags t = t
-
-addRelativeImport :: NormalizedFilePath -> ModuleName -> DynFlags -> DynFlags
-addRelativeImport fp modu dflags = dflags
-    {importPaths = nubOrd $ maybeToList (moduleImportPath fp modu) ++ importPaths dflags}
 
 mkTcModuleResult
     :: GhcMonad m

--- a/src/Development/IDE/Core/FileStore.hs
+++ b/src/Development/IDE/Core/FileStore.hs
@@ -252,7 +252,7 @@ typecheckParents state nfp = void $ shakeEnqueue (shakeExtras state) parents
 
 typecheckParentsAction :: NormalizedFilePath -> Action ()
 typecheckParentsAction nfp = do
-    fs <- useNoFile_ GetKnownFiles
+    fs <- useNoFile_ GetKnownTargets
     unless (null fs) $ do
       revs <- reverseDependencies nfp <$> useNoFile_ GetModuleGraph
       logger <- logger <$> getShakeExtras

--- a/src/Development/IDE/Core/FileStore.hs
+++ b/src/Development/IDE/Core/FileStore.hs
@@ -252,15 +252,13 @@ typecheckParents state nfp = void $ shakeEnqueue (shakeExtras state) parents
 
 typecheckParentsAction :: NormalizedFilePath -> Action ()
 typecheckParentsAction nfp = do
-    fs <- useNoFile_ GetKnownTargets
-    unless (null fs) $ do
-      revs <- reverseDependencies nfp <$> useNoFile_ GetModuleGraph
-      logger <- logger <$> getShakeExtras
-      let log = L.logInfo logger . T.pack
-      liftIO $ do
-        (log $ "Typechecking reverse dependencies for" ++ show nfp ++ ": " ++ show revs)
-          `catch` \(e :: SomeException) -> log (show e)
-      () <$ uses GetModIface revs
+    revs <- reverseDependencies nfp <$> useNoFile_ GetModuleGraph
+    logger <- logger <$> getShakeExtras
+    let log = L.logInfo logger . T.pack
+    liftIO $ do
+      (log $ "Typechecking reverse dependencies for" ++ show nfp ++ ": " ++ show revs)
+        `catch` \(e :: SomeException) -> log (show e)
+    () <$ uses GetModIface revs
 
 -- | Note that some buffer somewhere has been modified, but don't say what.
 --   Only valid if the virtual file system was initialised by LSP, as that

--- a/src/Development/IDE/Core/RuleTypes.hs
+++ b/src/Development/IDE/Core/RuleTypes.hs
@@ -16,10 +16,10 @@ import Data.Binary
 import           Development.IDE.Import.DependencyInformation
 import Development.IDE.GHC.Compat
 import Development.IDE.GHC.Util
+import Development.IDE.Core.Shake (KnownTargets)
 import           Data.Hashable
 import           Data.Typeable
 import qualified Data.Set as S
-import qualified Data.HashSet                             as HS
 import           Development.Shake
 import           GHC.Generics                             (Generic)
 
@@ -29,7 +29,6 @@ import HscTypes (hm_iface, CgGuts, Linkable, HomeModInfo, ModDetails)
 import           Development.IDE.Spans.Type
 import           Development.IDE.Import.FindImports (ArtifactsLocation)
 import Data.ByteString (ByteString)
-import Language.Haskell.LSP.Types (NormalizedFilePath)
 
 
 -- NOTATION
@@ -50,12 +49,12 @@ type instance RuleResult GetDependencies = TransitiveDependencies
 
 type instance RuleResult GetModuleGraph = DependencyInformation
 
-data GetKnownFiles = GetKnownFiles
+data GetKnownTargets = GetKnownTargets
   deriving (Show, Generic, Eq, Ord)
-instance Hashable GetKnownFiles
-instance NFData   GetKnownFiles
-instance Binary   GetKnownFiles
-type instance RuleResult GetKnownFiles = HS.HashSet NormalizedFilePath
+instance Hashable GetKnownTargets
+instance NFData   GetKnownTargets
+instance Binary   GetKnownTargets
+type instance RuleResult GetKnownTargets = KnownTargets
 
 -- | Contains the typechecked module and the OrigNameCache entry for
 -- that module.

--- a/src/Development/IDE/Core/Rules.hs
+++ b/src/Development/IDE/Core/Rules.hs
@@ -328,9 +328,13 @@ getLocatedImportsRule =
         let env = hscEnvWithImportPaths env_eq
         let import_dirs = deps env_eq
         let dflags = hsc_dflags env
+            isImplicitCradle = envImportPaths env_eq == Nothing
+        dflags <- return $ if isImplicitCradle
+                    then addRelativeImport file (moduleName $ ms_mod ms) dflags
+                    else dflags
         opt <- getIdeOptions
         let getTargetExists nfp
-                | HashSet.null targets || nfp `HashSet.member` targets = getFileExists nfp
+                | isImplicitCradle || nfp `HashSet.member` targets = getFileExists nfp
                 | otherwise = return False
         (diags, imports') <- fmap unzip $ forM imports $ \(isSource, (mbPkgName, modName)) -> do
             diagOrImp <- locateModule dflags import_dirs (optExtensions opt) getTargetExists modName mbPkgName isSource

--- a/src/Development/IDE/Core/Rules.hs
+++ b/src/Development/IDE/Core/Rules.hs
@@ -328,7 +328,7 @@ getLocatedImportsRule =
         let env = hscEnvWithImportPaths env_eq
         let import_dirs = deps env_eq
         let dflags = hsc_dflags env
-            isImplicitCradle = envImportPaths env_eq == Nothing
+            isImplicitCradle = isNothing $ envImportPaths env_eq
         dflags <- return $ if isImplicitCradle
                     then addRelativeImport file (moduleName $ ms_mod ms) dflags
                     else dflags

--- a/src/Development/IDE/Core/Rules.hs
+++ b/src/Development/IDE/Core/Rules.hs
@@ -322,7 +322,7 @@ getLocatedImportsRule :: Rules ()
 getLocatedImportsRule =
     define $ \GetLocatedImports file -> do
         ms <- use_ GetModSummaryWithoutTimestamps file
-        targets <- useNoFile_ GetKnownFiles
+        targets <- toKnownFiles <$> useNoFile_ GetKnownTargets
         let imports = [(False, imp) | imp <- ms_textual_imps ms] ++ [(True, imp) | imp <- ms_srcimps ms]
         env_eq <- use_ GhcSession file
         let env = hscEnvWithImportPaths env_eq
@@ -536,14 +536,14 @@ typeCheckRule = define $ \TypeCheck file -> do
     typeCheckRuleDefinition hsc pm isFoi (Just source)
 
 knownFilesRule :: Rules ()
-knownFilesRule = defineEarlyCutOffNoFile $ \GetKnownFiles -> do
+knownFilesRule = defineEarlyCutOffNoFile $ \GetKnownTargets -> do
   alwaysRerun
-  fs <- knownFiles
+  fs <- knownTargets
   pure (BS.pack (show $ hash fs), unhashed fs)
 
 getModuleGraphRule :: Rules ()
 getModuleGraphRule = defineNoFile $ \GetModuleGraph -> do
-  fs <- useNoFile_ GetKnownFiles
+  fs <- toKnownFiles <$> useNoFile_ GetKnownTargets
   rawDepInfo <- rawDependencyInformation (HashSet.toList fs)
   pure $ processDependencyInformation rawDepInfo
 

--- a/src/Development/IDE/Core/Rules.hs
+++ b/src/Development/IDE/Core/Rules.hs
@@ -327,7 +327,7 @@ getLocatedImportsRule =
         env_eq <- use_ GhcSession file
         let env = hscEnvWithImportPaths env_eq
         let import_dirs = deps env_eq
-        let dflags = addRelativeImport file (moduleName $ ms_mod ms) $ hsc_dflags env
+        let dflags = hsc_dflags env
         opt <- getIdeOptions
         let getTargetExists nfp
                 | HashSet.null targets || nfp `HashSet.member` targets = getFileExists nfp
@@ -683,7 +683,7 @@ ghcSessionDepsDefinition file = do
             setupFinderCache (map hirModSummary ifaces)
             mapM_ (uncurry loadDepModule) inLoadOrder
 
-        res <- liftIO $ newHscEnvEq session' []
+        res <- liftIO $ newHscEnvEq "" session' []
         return ([], Just res)
  where
   unpack HiFileResult{..} bc = (hirModIface, bc)

--- a/src/Development/IDE/GHC/Orphans.hs
+++ b/src/Development/IDE/GHC/Orphans.hs
@@ -75,3 +75,8 @@ deriving instance Eq SourceModified
 deriving instance Show SourceModified
 instance NFData SourceModified where
     rnf = rwhnf
+
+instance Show ModuleName where
+    show = moduleNameString
+instance Hashable ModuleName where
+    hashWithSalt salt = hashWithSalt salt . show

--- a/src/Development/IDE/GHC/Util.hs
+++ b/src/Development/IDE/GHC/Util.hs
@@ -7,6 +7,7 @@ module Development.IDE.GHC.Util(
     HscEnvEq,
     hscEnv, newHscEnvEq,
     hscEnvWithImportPaths,
+    envImportPaths,
     modifyDynFlags,
     evalGhcEnv,
     runGhcEnv,

--- a/src/Development/IDE/GHC/Util.hs
+++ b/src/Development/IDE/GHC/Util.hs
@@ -184,10 +184,11 @@ data HscEnvEq = HscEnvEq
     }
 
 -- | Wrap an 'HscEnv' into an 'HscEnvEq'.
-newHscEnvEq :: HscEnv -> [(InstalledUnitId, DynFlags)] -> IO HscEnvEq
-newHscEnvEq hscEnv0 deps = do
+newHscEnvEq :: FilePath -> HscEnv -> [(InstalledUnitId, DynFlags)] -> IO HscEnvEq
+newHscEnvEq cradlePath hscEnv0 deps = do
     envUnique <- newUnique
-    let envImportPaths = Just $ importPaths $ hsc_dflags hscEnv0
+    let envImportPaths = Just $ relativeToCradle <$> importPaths (hsc_dflags hscEnv0)
+        relativeToCradle = (takeDirectory cradlePath </>)
         hscEnv = removeImportPaths hscEnv0
     return HscEnvEq{..}
 

--- a/test/exe/Main.hs
+++ b/test/exe/Main.hs
@@ -2917,11 +2917,11 @@ simpleMultiTest2 = testCase "simple-multi-test2" $ withoutStackEnv $ runWithExtr
         bPath = dir </> "b/B.hs"
     bSource <- liftIO $ readFileUtf8 bPath
     bdoc <- createDoc bPath "haskell" bSource
-    expectNoMoreDiagnostics 5
+    expectNoMoreDiagnostics 10
     aSource <- liftIO $ readFileUtf8 aPath
     (TextDocumentIdentifier adoc) <- createDoc aPath "haskell" aSource
     -- Need to have some delay here or the test fails
-    expectNoMoreDiagnostics 6
+    expectNoMoreDiagnostics 10
     locs <- getDefinitions bdoc (Position 2 7)
     let fooL = mkL adoc 2 0 2 3
     checkDefs locs (pure [fooL])

--- a/test/exe/Main.hs
+++ b/test/exe/Main.hs
@@ -533,7 +533,7 @@ codeLensesTests = testGroup "code lenses"
 watchedFilesTests :: TestTree
 watchedFilesTests = testGroup "watched files"
   [ testSession' "workspace files" $ \sessionDir -> do
-      liftIO $ writeFile (sessionDir </> "hie.yaml") "cradle: {direct: {arguments: [\"-isrc\"]}}"
+      liftIO $ writeFile (sessionDir </> "hie.yaml") "cradle: {direct: {arguments: [\"-isrc\", \"A\", \"WatchedFilesMissingModule\"]}}"
       _doc <- createDoc "A.hs" "haskell" "{-#LANGUAGE NoImplicitPrelude #-}\nmodule A where\nimport WatchedFilesMissingModule"
       watchedFileRegs <- getWatchedFilesSubscriptionsUntil @PublishDiagnosticsNotification
 
@@ -546,7 +546,7 @@ watchedFilesTests = testGroup "watched files"
       liftIO $ length watchedFileRegs @?= 5
 
   , testSession' "non workspace file" $ \sessionDir -> do
-      liftIO $ writeFile (sessionDir </> "hie.yaml") "cradle: {direct: {arguments: [\"-i/tmp\"]}}"
+      liftIO $ writeFile (sessionDir </> "hie.yaml") "cradle: {direct: {arguments: [\"-i/tmp\", \"A\", \"WatchedFilesMissingModule\"]}}"
       _doc <- createDoc "A.hs" "haskell" "{-# LANGUAGE NoImplicitPrelude#-}\nmodule A where\nimport WatchedFilesMissingModule"
       watchedFileRegs <- getWatchedFilesSubscriptionsUntil @PublishDiagnosticsNotification
 

--- a/test/exe/Main.hs
+++ b/test/exe/Main.hs
@@ -3267,7 +3267,7 @@ runInDir' dir startExeIn startSessionIn s = do
   -- since the package import test creates "Data/List.hs", which otherwise has no physical home
   createDirectoryIfMissing True $ projDir ++ "/Data"
 
-  let cmd = unwords [ghcideExe, "--lsp", "--test", "--cwd", startDir]
+  let cmd = unwords [ghcideExe, "--lsp", "--test", "--verbose", "--cwd", startDir]
   -- HIE calls getXgdDirectory which assumes that HOME is set.
   -- Only sets HOME if it wasn't already set.
   setEnv "HOME" "/homeless-shelter" False

--- a/test/exe/Main.hs
+++ b/test/exe/Main.hs
@@ -2931,7 +2931,8 @@ ifaceTests :: TestTree
 ifaceTests = testGroup "Interface loading tests"
     [ -- https://github.com/digital-asset/ghcide/pull/645/
       ifaceErrorTest
-    , ifaceErrorTest2
+    -- https://github.com/haskell/ghcide/pull/781
+    , ignoreTestBecause "too flaky" ifaceErrorTest2
     , ifaceErrorTest3
     , ifaceTHTest
     ]
@@ -3056,6 +3057,10 @@ ifaceErrorTest2 = testCase "iface-error-test-2" $ withoutStackEnv $ runWithExtra
       ,("P.hs", [(DsWarning,(4,0), "Top-level binding")])
       ,("P.hs", [(DsWarning,(6,0), "Top-level binding")])
       ]
+    -- FLAKY: 1 out of 5 times in CI ghcide does not send any diagnostics back,
+    --        not even for P, which makes the expectDiagnostics above to time out
+    --        cannot repro locally even after wiping the interface cache dir
+
     expectNoMoreDiagnostics 2
 
 ifaceErrorTest3 :: TestTree

--- a/test/exe/Main.hs
+++ b/test/exe/Main.hs
@@ -3272,14 +3272,19 @@ runInDir' dir startExeIn startSessionIn s = do
   -- Only sets HOME if it wasn't already set.
   setEnv "HOME" "/homeless-shelter" False
   let lspTestCaps = fullCaps { _window = Just $ WindowClientCapabilities $ Just True }
-  runSessionWithConfig conf cmd lspTestCaps projDir s
+  logColor <- fromMaybe True <$> checkEnv "LSP_TEST_LOG_COLOR"
+  runSessionWithConfig conf{logColor} cmd lspTestCaps projDir s
   where
+    checkEnv :: String -> IO (Maybe Bool)
+    checkEnv s = fmap convertVal <$> getEnv s
+    convertVal "0" = False
+    convertVal _ = True
+
     conf = defaultConfig
-      -- If you uncomment this you can see all logging
-      -- which can be quite useful for debugging.
-    --   { logStdErr = True, logColor = False }
-    --   If you really want to, you can also see all messages
-    --   { logMessages = True, logColor = False }
+      -- uncomment this or set LSP_TEST_LOG_STDERR=1 to see all logging
+    --   { logStdErr = True }
+    --   uncomment this or set LSP_TEST_LOG_MESSAGES=1 to see all messages
+    --   { logMessages = True }
 
 openTestDataDoc :: FilePath -> Session TextDocumentIdentifier
 openTestDataDoc path = do


### PR DESCRIPTION
I noticed ghcide HEAD was broken on the ghcide submodule of the haskell-language-server repo, after the recent changes to import paths. Hopefully this fixes the issue

Fixes #780 