### PR TITLE
Fix setFileModified and restore test

### DIFF
--- a/.azure/linux-stack.yml
+++ b/.azure/linux-stack.yml
@@ -45,7 +45,7 @@ jobs:
     displayName: 'stack build --only-dependencies'
   - bash: |
       export PATH=/opt/cabal/bin:$PATH
-      stack test --ghc-options=-Werror  --stack-yaml=$STACK_YAML || stack test --ghc-options=-Werror --stack-yaml=$STACK_YAML|| LSP_TEST_LOG_COLOR=0 LSP_TEST_LOG_MESSAGES=true LSP_TEST_LOG_STDERR=true stack test --ghc-options=-Werror --stack-yaml=$STACK_YAML
+      stack test --ghc-options=-Werror  --stack-yaml=$STACK_YAML || stack test --ghc-options=-Werror --stack-yaml=$STACK_YAML --ta "--rerun" || LSP_TEST_LOG_COLOR=0 LSP_TEST_LOG_MESSAGES=true LSP_TEST_LOG_STDERR=true stack test --ghc-options=-Werror --stack-yaml=$STACK_YAML --ta "--rerun"
     # ghcide stack tests are flaky, see https://github.com/digital-asset/daml/issues/2606.
     displayName: 'stack test --ghc-options=-Werror'
   - bash: |


### PR DESCRIPTION
This test failure did hide a real bug after all. We need to type check all the parents of the modified file, restricted to the files of interest. That's precisely what kick does.