### PR TITLE
Disable optimisation in tests

### DIFF
--- a/ghcide.cabal
+++ b/ghcide.cabal
@@ -355,7 +355,7 @@ test-suite ghcide-tests
         text
     hs-source-dirs: test/cabal test/exe test/src bench/lib
     include-dirs: include
-    ghc-options: -threaded -Wall -Wno-name-shadowing
+    ghc-options: -Wall -Wno-name-shadowing -O0
     main-is: Main.hs
     other-modules:
         Development.IDE.Test


### PR DESCRIPTION
Ideally we would do this with a Cabal flag, but I don't think it is possible
to disable optimisation only for the tests stanza