### PR TITLE
Skip unnecessary packing of cache artifacts

### DIFF
--- a/.azure/linux-bench.yml
+++ b/.azure/linux-bench.yml
@@ -31,15 +31,15 @@ jobs:
   - bash: stack setup --stack-yaml=$STACK_YAML
     displayName: 'stack setup'
   - bash: stack build --bench --only-dependencies --stack-yaml=$STACK_YAML
-    displayName: 'stack build --only-dependencies'
-  - bash: |
-      export PATH=/opt/cabal/bin:$PATH
-      stack bench --ghc-options=-Werror  --stack-yaml=$STACK_YAML
-    displayName: 'stack bench --ghc-options=-Werror'
+    displayName: 'stack build --bench --only-dependencies'
   - bash: |
       mkdir -p .azure-cache
       tar czf .azure-cache/stack-root.tar.gz -C $HOME .stack
     displayName: "Pack cache"
+  - bash: |
+      export PATH=/opt/cabal/bin:$PATH
+      stack bench --ghc-options=-Werror  --stack-yaml=$STACK_YAML
+    displayName: 'stack bench --ghc-options=-Werror'
   - bash: |
       cat bench-hist/results.csv
     displayName: "cat results"

--- a/.azure/linux-stack.yml
+++ b/.azure/linux-stack.yml
@@ -44,12 +44,12 @@ jobs:
   - bash: stack build --only-dependencies --stack-yaml=$STACK_YAML
     displayName: 'stack build --only-dependencies'
   - bash: |
-      export PATH=/opt/cabal/bin:$PATH
-      stack test --ghc-options=-Werror  --stack-yaml=$STACK_YAML || stack test --ghc-options=-Werror --stack-yaml=$STACK_YAML --ta "--rerun" || LSP_TEST_LOG_COLOR=0 LSP_TEST_LOG_MESSAGES=true LSP_TEST_LOG_STDERR=true stack test --ghc-options=-Werror --stack-yaml=$STACK_YAML --ta "--rerun"
-    # ghcide stack tests are flaky, see https://github.com/digital-asset/daml/issues/2606.
-    displayName: 'stack test --ghc-options=-Werror'
-  - bash: |
       mkdir -p .azure-cache
       tar czf .azure-cache/stack-root.tar.gz -C $HOME .stack
     displayName: "Pack cache"
     condition: eq(variables.CACHE_RESTORED, 'false')
+  - bash: |
+      export PATH=/opt/cabal/bin:$PATH
+      stack test --ghc-options=-Werror  --stack-yaml=$STACK_YAML || stack test --ghc-options=-Werror --stack-yaml=$STACK_YAML --ta "--rerun" || LSP_TEST_LOG_COLOR=0 LSP_TEST_LOG_MESSAGES=true LSP_TEST_LOG_STDERR=true stack test --ghc-options=-Werror --stack-yaml=$STACK_YAML --ta "--rerun"
+    # ghcide stack tests are flaky, see https://github.com/digital-asset/daml/issues/2606.
+    displayName: 'stack test --ghc-options=-Werror'

--- a/.azure/linux-stack.yml
+++ b/.azure/linux-stack.yml
@@ -52,3 +52,4 @@ jobs:
       mkdir -p .azure-cache
       tar czf .azure-cache/stack-root.tar.gz -C $HOME .stack
     displayName: "Pack cache"
+    condition: eq(variables.CACHE_RESTORED, 'false')

--- a/.azure/windows-stack.yml
+++ b/.azure/windows-stack.yml
@@ -56,6 +56,11 @@ jobs:
       fi
     displayName: 'stack build --only-dependencies'
   - bash: |
+      mkdir -p .azure-cache
+      tar -vczf .azure-cache/stack-root.tar.gz $(cygpath $STACK_ROOT)
+      tar -vczf .azure-cache/stack-work.tar.gz .stack-work
+    displayName: "Pack cache"
+  - bash: |
       if [ "$STACK_YAML" = "stack8101.yaml" ]; then
         stack test --no-run-tests --ghc-options="-Werror -fexternal-interpreter" --stack-yaml $STACK_YAML || stack test --no-run-tests --ghc-options="-Werror -fexternal-interpreter" --stack-yaml $STACK_YAML || stack test --no-run-tests --ghc-options="-Werror -fexternal-interpreter" --stack-yaml $STACK_YAML
       else
@@ -63,8 +68,3 @@ jobs:
       fi
     displayName: 'stack test --ghc-options=-Werror'
     # TODO: run test suite when failing tests are fixed or marked as broken. See https://github.com/digital-asset/ghcide/issues/474
-  - bash: |
-      mkdir -p .azure-cache
-      tar -vczf .azure-cache/stack-root.tar.gz $(cygpath $STACK_ROOT)
-      tar -vczf .azure-cache/stack-work.tar.gz .stack-work
-    displayName: "Pack cache"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,5 +16,4 @@ pr:
 jobs:
   - template: ./.azure/linux-stack.yml
   - template: ./.azure/windows-stack.yml
-# https://github.com/haskell/ghcide/pull/801
-#   - template: ./.azure/linux-bench.yml
+  - template: ./.azure/linux-bench.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,5 +15,5 @@ pr:
 
 jobs:
   - template: ./.azure/linux-stack.yml
-  - template: ./.azure/windows-stack.yml
+#  - template: ./.azure/windows-stack.yml
   - template: ./.azure/linux-bench.yml


### PR DESCRIPTION
Not needed when we had a successful cache hit, saves ~ 2 minutes