### PR TITLE
Fix import suggestions when dot is typed

### DIFF
--- a/src/Development/IDE/Plugin/Completions.hs
+++ b/src/Development/IDE/Plugin/Completions.hs
@@ -149,7 +149,7 @@ getCompletionsLSP lsp ide
             pure (opts, liftA2 (,) compls pm)
         case compls of
           Just ((cci', _), (pm, mapping)) -> do
-            pfix <- maybe (return Nothing) (flip VFS.getCompletionPrefix cnts) (Just position)
+            pfix <- VFS.getCompletionPrefix position cnts
             case (pfix, completionContext) of
               (Just (VFS.PosPrefixInfo _ "" _ _), Just CompletionContext { _triggerCharacter = Just "."})
                 -> return (Completions $ List [])

--- a/src/Development/IDE/Plugin/Completions.hs
+++ b/src/Development/IDE/Plugin/Completions.hs
@@ -24,7 +24,6 @@ import Development.IDE.Plugin.Completions.Logic
 import Development.IDE.Types.Location
 import Development.IDE.Types.Options
 import Development.IDE.Core.Compile
-import Development.IDE.Core.PositionMapping
 import Development.IDE.Core.RuleTypes
 import Development.IDE.Core.Shake
 import Development.IDE.GHC.Compat (hsmodExports, ParsedModule(..), ModSummary (ms_hspp_buf))
@@ -150,15 +149,14 @@ getCompletionsLSP lsp ide
             pure (opts, liftA2 (,) compls pm)
         case compls of
           Just ((cci', _), (pm, mapping)) -> do
-            let !position' = fromCurrentPosition mapping position
-            pfix <- maybe (return Nothing) (flip VFS.getCompletionPrefix cnts) position'
+            pfix <- maybe (return Nothing) (flip VFS.getCompletionPrefix cnts) (Just position)
             case (pfix, completionContext) of
               (Just (VFS.PosPrefixInfo _ "" _ _), Just CompletionContext { _triggerCharacter = Just "."})
                 -> return (Completions $ List [])
               (Just pfix', _) -> do
                   -- TODO pass the real capabilities here (or remove the logic for snippets)
                 let fakeClientCapabilities = ClientCapabilities Nothing Nothing Nothing Nothing
-                Completions . List <$> getCompletions ideOpts cci' pm pfix' fakeClientCapabilities (WithSnippets True)
+                Completions . List <$> getCompletions ideOpts cci' pm mapping pfix' fakeClientCapabilities (WithSnippets True)
               _ -> return (Completions $ List [])
           _ -> return (Completions $ List [])
       _ -> return (Completions $ List [])

--- a/src/Development/IDE/Plugin/Completions/Logic.hs
+++ b/src/Development/IDE/Plugin/Completions/Logic.hs
@@ -376,7 +376,7 @@ getCompletions
     :: IdeOptions
     -> CachedCompletions
     -> ParsedModule
-    -> PositionMapping
+    -> PositionMapping     -- ^ map current position to position in parsed module
     -> VFS.PosPrefixInfo
     -> ClientCapabilities
     -> WithSnippets

--- a/src/Development/IDE/Plugin/Completions/Logic.hs
+++ b/src/Development/IDE/Plugin/Completions/Logic.hs
@@ -38,6 +38,7 @@ import Language.Haskell.LSP.Types
 import Language.Haskell.LSP.Types.Capabilities
 import qualified Language.Haskell.LSP.VFS as VFS
 import Development.IDE.Core.Compile
+import Development.IDE.Core.PositionMapping
 import Development.IDE.Plugin.Completions.Types
 import Development.IDE.Spans.Documentation
 import Development.IDE.GHC.Compat as GHC
@@ -371,10 +372,18 @@ toggleSnippets ClientCapabilities { _textDocument } (WithSnippets with) x
   where supported = Just True == (_textDocument >>= _completion >>= _completionItem >>= _snippetSupport)
 
 -- | Returns the cached completions for the given module and position.
-getCompletions :: IdeOptions -> CachedCompletions -> ParsedModule -> VFS.PosPrefixInfo -> ClientCapabilities -> WithSnippets -> IO [CompletionItem]
-getCompletions ideOpts CC { allModNamesAsNS, unqualCompls, qualCompls, importableModules }
-               pm prefixInfo caps withSnippets = do
-  let VFS.PosPrefixInfo { VFS.fullLine, VFS.prefixModule, VFS.prefixText } = prefixInfo
+getCompletions
+    :: IdeOptions
+    -> CachedCompletions
+    -> ParsedModule
+    -> PositionMapping
+    -> VFS.PosPrefixInfo
+    -> ClientCapabilities
+    -> WithSnippets
+    -> IO [CompletionItem]
+getCompletions ideOpts cc pm pmapping prefixInfo caps withSnippets = do
+  let CC { allModNamesAsNS, unqualCompls, qualCompls, importableModules } = cc
+      VFS.PosPrefixInfo { VFS.fullLine, VFS.prefixModule, VFS.prefixText } = prefixInfo
       enteredQual = if T.null prefixModule then "" else prefixModule <> "."
       fullPrefix  = enteredQual <> prefixText
 
@@ -404,8 +413,12 @@ getCompletions ideOpts CC { allModNamesAsNS, unqualCompls, qualCompls, importabl
 
       filtCompls = map Fuzzy.original $ Fuzzy.filter prefixText ctxCompls "" "" label False
         where
+          mcc = do
+              position' <- fromCurrentPosition pmapping pos
+              getCContext position' pm
+
           -- completions specific to the current context
-          ctxCompls' = case getCContext pos pm of
+          ctxCompls' = case mcc of
                         Nothing -> compls
                         Just TypeContext -> filter isTypeCompl compls
                         Just ValueContext -> filter (not . isTypeCompl) compls


### PR DESCRIPTION
Fixes #613 and [#342](https://github.com/haskell/haskell-language-server/issues/342) at haskell-language-server.

## Before
![Before](https://user-images.githubusercontent.com/11493705/93029336-3955f400-f612-11ea-9550-1a9b21129518.gif)

## After
![Untitled](https://user-images.githubusercontent.com/11493705/93028717-85eb0080-f60d-11ea-900a-b1b613a64ee8.gif)

