### PR TITLE
Mark files as modified on open

### DIFF
--- a/src/Development/IDE/LSP/Notifications.hs
+++ b/src/Development/IDE/LSP/Notifications.hs
@@ -41,7 +41,9 @@ setHandlersNotifications = PartialHandlers $ \WithMessage{..} x -> return x
         \_ ide (DidOpenTextDocumentParams TextDocumentItem{_uri,_version}) -> do
             updatePositionMapping ide (VersionedTextDocumentIdentifier _uri (Just _version)) (List [])
             whenUriFile _uri $ \file -> do
-                modifyFilesOfInterest ide (M.insert file OnDisk)
+                -- We don't know if the file actually exists, or if the contents match those on disk
+                -- For example, vscode restores previously unsaved contents on open
+                modifyFilesOfInterest ide (M.insert file Modified)
                 setFileModified ide False file
                 logInfo (ideLogger ide) $ "Opened text document: " <> getUri _uri
 

--- a/test/exe/Main.hs
+++ b/test/exe/Main.hs
@@ -3011,6 +3011,11 @@ ifaceErrorTest = testCase "iface-error-test-1" $ withoutStackEnv $ runWithExtraF
     -- save so that we can that the error propogates to A
     sendNotification TextDocumentDidSave (DidSaveTextDocumentParams bdoc)
 
+    -- Check that the error propogates to A
+    expectDiagnostics
+      [("A.hs", [(DsError, (5, 4), "Couldn't match expected type 'Int' with actual type 'Bool'")])]
+
+
     -- Check that we wrote the interfaces for B when we saved
     lid <- sendRequest (CustomClientMethod "hidir") $ GetInterfaceFilesDir bPath
     res <- skipManyTill (message :: Session WorkDoneProgressCreateRequest) $
@@ -3025,10 +3030,6 @@ ifaceErrorTest = testCase "iface-error-test-1" $ withoutStackEnv $ runWithExtraF
         assertBool ("Couldn't find B.hie in " ++ hidir) hie_exists
 #endif
       _ -> assertFailure $ "Got malformed response for CustomMessage hidir: " ++ show res
-
-    -- Check that the error propogates to A
-    expectDiagnostics
-      [("A.hs", [(DsError, (5, 4), "Couldn't match expected type 'Int' with actual type 'Bool'")])]
 
     pdoc <- createDoc pPath "haskell" pSource
     changeDoc pdoc [TextDocumentContentChangeEvent Nothing Nothing $ pSource <> "\nfoo = y :: Bool" ]


### PR DESCRIPTION
Initially I thought I would check if the file exists on disk, but then I realized that vscode violates our assumptions anyway, so we should mark it as `Modified` to be safe.