### PR TITLE
Tag unused warning as such

### DIFF
--- a/src/Development/IDE/Core/Compile.hs
+++ b/src/Development/IDE/Core/Compile.hs
@@ -269,7 +269,9 @@ tagDiag (Reason warning, (nfp, sh, fd))
 #if MIN_GHC_API_VERSION(8,10,0)
     requiresTag Opt_WarnUnusedRecordWildcards = Just DtUnnecessary
 #endif
+#if MIN_GHC_API_VERSION(8,6,0)
     requiresTag Opt_WarnInaccessibleCode      = Just DtUnnecessary
+#endif
     requiresTag Opt_WarnWarningsDeprecations  = Just DtDeprecated
     requiresTag _ = Nothing
     addTag :: DiagnosticTag -> Maybe (List DiagnosticTag) -> Maybe (List DiagnosticTag)

--- a/test/data/hover/GotoHover.hs
+++ b/test/data/hover/GotoHover.hs
@@ -48,7 +48,7 @@ documented = Left 7518
 listOfInt = [ 8391 :: Int, 6268 ]
 
 outer :: Bool
-outer = undefined where
+outer = undefined inner where
 
   inner :: Char
   inner = undefined

--- a/test/exe/Main.hs
+++ b/test/exe/Main.hs
@@ -327,7 +327,14 @@ diagnosticTests = testGroup "diagnostics"
       _ <- createDoc "ModuleA.hs" "haskell" contentA
       _ <- createDoc "ModuleB.hs" "haskell" contentB
       _ <- createDoc "ModuleB.hs-boot" "haskell" contentBboot
-      expectDiagnostics []
+      expectDiagnosticsWithTags
+        [ ( "ModuleA.hs"
+          , [(DsInfo, (1, 0), "The import of 'ModuleB'", Just DtUnnecessary)]
+          )
+        , ( "ModuleB.hs"
+          , [(DsInfo, (1, 0), "The import of 'ModuleA'", Just DtUnnecessary)]
+          )
+        ]
   , testSessionWait "correct reference used with hs-boot" $ do
       let contentB = T.unlines
             [ "module ModuleB where"

--- a/test/exe/Main.hs
+++ b/test/exe/Main.hs
@@ -361,9 +361,9 @@ diagnosticTests = testGroup "diagnostics"
             ]
       _ <- createDoc "ModuleA.hs" "haskell" contentA
       _ <- createDoc "ModuleB.hs" "haskell" contentB
-      expectDiagnostics
+      expectDiagnostics_
         [ ( "ModuleB.hs"
-          , [(DsWarning, (2, 0), "The import of 'ModuleA' is redundant")]
+          , [(DsWarning, (2, 0), "The import of 'ModuleA' is redundant", Just DtUnnecessary)]
           )
         ]
   , testSessionWait "package imports" $ do


### PR DESCRIPTION
This patch uses the new "unnecessary" or "deprecated" tags for diagnostics to show unused variables/functions/... dimmed in the editor, as discussed in https://github.com/haskell/ghcide/issues/165#issuecomment-692532054