### PR TITLE
Preserve more information about targets

### DIFF
--- a/session-loader/Development/IDE/Session.hs
+++ b/session-loader/Development/IDE/Session.hs
@@ -34,7 +34,8 @@ import Data.Version
 import Development.IDE.Core.OfInterest
 import Development.IDE.Core.Shake
 import Development.IDE.Core.RuleTypes
-import Development.IDE.GHC.Compat
+import Development.IDE.GHC.Compat hiding (Target, TargetModule, TargetFile)
+import qualified Development.IDE.GHC.Compat as GHC
 import Development.IDE.GHC.Util
 import Development.IDE.Session.VersionCheck
 import Development.IDE.Types.Diagnostics
@@ -59,13 +60,12 @@ import System.IO
 
 import GHCi
 import DynFlags
-import HscTypes
+import HscTypes (ic_dflags, hsc_IC, hsc_dflags, hsc_NC)
 import Linker
 import Module
 import NameCache
 import Packages
 import Control.Exception (evaluate)
-import Data.Char
 
 -- | Given a root directory, return a Shake 'Action' which setups an
 -- 'IdeGhcSession' given a file.
@@ -120,7 +120,7 @@ loadSession dir = do
     let extendKnownTargets newTargets = do
           knownTargets <- forM newTargets $ \TargetDetails{..} -> do
             found <- filterM (IO.doesFileExist . fromNormalizedFilePath) targetLocations
-            return (targetModule, found)
+            return (targetTarget, found)
           modifyVar_ knownTargetsVar $ traverseHashed $ \known -> do
             let known' = HM.unionWith (<>) known $ HM.fromList knownTargets
             when (known /= known') $
@@ -374,7 +374,7 @@ emptyHscEnv nc libDir = do
 
 data TargetDetails = TargetDetails
   {
-      targetModule :: !ModuleName,
+      targetTarget :: !Target,
       targetEnv :: !(IdeResult HscEnvEq),
       targetDepends :: !DependencyInfo,
       targetLocations :: ![NormalizedFilePath]
@@ -387,29 +387,18 @@ fromTargetId :: [FilePath]          -- ^ import paths
              -> DependencyInfo
              -> IO [TargetDetails]
 -- For a target module we consider all the import paths
-fromTargetId is exts (TargetModule mod) env dep = do
+fromTargetId is exts (GHC.TargetModule mod) env dep = do
     let fps = [i </> moduleNameSlashes mod -<.> ext <> boot
               | ext <- exts
               , i <- is
               , boot <- ["", "-boot"]
               ]
     locs <- mapM (fmap toNormalizedFilePath' . canonicalizePath) fps
-    return [TargetDetails mod env dep locs]
+    return [TargetDetails (TargetModule mod) env dep locs]
 -- For a 'TargetFile' we consider all the possible module names
-fromTargetId _ _ (TargetFile f _) env deps = do
+fromTargetId _ _ (GHC.TargetFile f _) env deps = do
     nf <- toNormalizedFilePath' <$> canonicalizePath f
-    return [TargetDetails m env deps [nf] | m <- moduleNames f]
-
--- >>> moduleNames "src/A/B.hs"
--- [A.B,B]
-moduleNames :: FilePath -> [ModuleName]
-moduleNames f = map (mkModuleName .intercalate ".") $ init $ tails nameSegments
-    where
-        nameSegments = reverse
-                     $ takeWhile (isUpper . head)
-                     $ reverse
-                     $ splitDirectories
-                     $ dropExtension f
+    return [TargetDetails (TargetFile nf) env deps [nf]]
 
 toFlagsMap :: TargetDetails -> [(NormalizedFilePath, (IdeResult HscEnvEq, DependencyInfo))]
 toFlagsMap TargetDetails{..} =
@@ -448,7 +437,8 @@ newComponentCache logger exts cradlePath hsc_env uids ci = do
     -- the component, in which case things will be horribly broken anyway.
     -- Otherwise, we will immediately attempt to reload this module which
     -- causes an infinite loop and high CPU usage.
-    let special_target = TargetDetails (mkModuleName "special") targetEnv targetDepends [componentFP ci]
+    let special_target = TargetDetails (TargetModule m) targetEnv targetDepends [componentFP ci]
+        m = mkModuleName "special"
     return (special_target:ctargets, res)
 
 {- Note [Avoiding bad interface files]
@@ -531,7 +521,7 @@ data RawComponentInfo = RawComponentInfo
   -- We do not want to use them unprocessed.
   , rawComponentDynFlags :: DynFlags
   -- | All targets of this components.
-  , rawComponentTargets :: [Target]
+  , rawComponentTargets :: [GHC.Target]
   -- | Filepath which caused the creation of this component
   , rawComponentFP :: NormalizedFilePath
   -- | Component Options used to load the component.
@@ -552,7 +542,7 @@ data ComponentInfo = ComponentInfo
   -- ComponentOptions.
   , _componentInternalUnits :: [InstalledUnitId]
   -- | All targets of this components.
-  , componentTargets :: [Target]
+  , componentTargets :: [GHC.Target]
   -- | Filepath which caused the creation of this component
   , componentFP :: NormalizedFilePath
   -- | Component Options used to load the component.
@@ -625,7 +615,7 @@ memoIO op = do
             Just res -> return (mp, res)
 
 -- | Throws if package flags are unsatisfiable
-setOptions :: GhcMonad m => ComponentOptions -> DynFlags -> m (DynFlags, [Target])
+setOptions :: GhcMonad m => ComponentOptions -> DynFlags -> m (DynFlags, [GHC.Target])
 setOptions (ComponentOptions theOpts compRoot _) dflags = do
     (dflags', targets) <- addCmdOpts theOpts dflags
     let dflags'' =

--- a/src/Development/IDE/Core/Rules.hs
+++ b/src/Development/IDE/Core/Rules.hs
@@ -46,7 +46,7 @@ import           Development.IDE.Core.FileExists
 import           Development.IDE.Core.FileStore        (modificationTime, getFileContents)
 import           Development.IDE.Types.Diagnostics as Diag
 import Development.IDE.Types.Location
-import Development.IDE.GHC.Compat hiding (parseModule, typecheckModule)
+import Development.IDE.GHC.Compat hiding (parseModule, typecheckModule, TargetModule, TargetFile)
 import Development.IDE.GHC.Util
 import Development.IDE.GHC.WithDynFlags
 import Data.Either.Extra
@@ -67,7 +67,7 @@ import qualified Data.ByteString.Char8 as BS
 import Development.IDE.Core.PositionMapping
 
 import qualified GHC.LanguageExtensions as LangExt
-import HscTypes
+import HscTypes hiding (TargetModule, TargetFile)
 import PackageConfig
 import DynFlags (gopt_set, xopt)
 import GHC.Generics(Generic)
@@ -336,7 +336,9 @@ getLocatedImportsRule =
         opt <- getIdeOptions
         let getTargetExists modName nfp
                 | isImplicitCradle = getFileExists nfp
-                | HM.member modName targets = getFileExists nfp
+                | HM.member (TargetModule modName) targets
+                || HM.member (TargetFile nfp) targets
+                = getFileExists nfp
                 | otherwise = return False
         (diags, imports') <- fmap unzip $ forM imports $ \(isSource, (mbPkgName, modName)) -> do
             diagOrImp <- locateModule dflags import_dirs (optExtensions opt) getTargetExists modName mbPkgName isSource


### PR DESCRIPTION
The problem we are trying to solve is accurately decide what modules belong to a cradle when there are multiple projects sharing the same source folder, and project membership is driven by a Bios cradle. 

For instance, say we have modules A,B,C in the same folder, and A,B should use the same set of flags whereas C should use a different set of flags. For A or B, the Bios cradle will return the set of flags F1 and the targets {A,B}. For C, the Bios cradle will return the set of flags F2 and the set of targets {C}. 

While editing A, when finding an `import C`, ghcide must not allow ghc to load `C`, and instead must locate it in a package. 

The improvement in this PR is to preserve more information from the set of targets returned by the cradle. Targets can be either file paths or modules. Previously we would only store modules, inferring possible module names from file paths targets which was lossy and unnecessary. The change here is to preserve either module names or file paths.