### PR TITLE
Enable test suite in Windows, marking failing tests as broken

### DIFF
--- a/.azure/windows-stack.yml
+++ b/.azure/windows-stack.yml
@@ -54,9 +54,8 @@ jobs:
     displayName: 'stack build --only-dependencies'
   - bash: |
       if [ "$STACK_YAML" = "stack8101.yaml" ]; then
-        stack test --no-run-tests --ghc-options="-Werror -fexternal-interpreter" --stack-yaml $STACK_YAML || stack test --no-run-tests --ghc-options="-Werror -fexternal-interpreter" --stack-yaml $STACK_YAML || stack test --no-run-tests --ghc-options="-Werror -fexternal-interpreter" --stack-yaml $STACK_YAML
+        stack test --ghc-options="-Werror -fexternal-interpreter" --stack-yaml $STACK_YAML
       else
-        stack test --no-run-tests --ghc-options=-Werror --stack-yaml $STACK_YAML
+        stack test --ghc-options=-Werror --stack-yaml $STACK_YAML
       fi
     displayName: 'stack test --ghc-options=-Werror'
-    # TODO: run test suite when failing tests are fixed or marked as broken. See https://github.com/digital-asset/ghcide/issues/474

--- a/.azure/windows-stack.yml
+++ b/.azure/windows-stack.yml
@@ -43,7 +43,8 @@ jobs:
       # Installing happy and alex standalone to avoid error "strip.exe: unable to rename ../*.exe; reason: File exists"
       stack install happy --stack-yaml $STACK_YAML
       stack install alex --stack-yaml $STACK_YAML
-      stack install cabal-install --stack-yaml $STACK_YAML
+      choco install -y cabal --version=$CABAL_VERSION
+      $(cygpath $ProgramData)/chocolatey/bin/RefreshEnv.cmd
       # GHC 8.10.1 fails with ghc segfaults, using -fexternal-interpreter seems to make it working
       # There are other transient errors like timeouts downloading from stackage so we retry 3 times
       if [ "$STACK_YAML" = "stack8101.yaml" ]; then

--- a/cabal.project
+++ b/cabal.project
@@ -1,7 +1,6 @@
 packages: .
 
-package ghcide
-  test-show-details: direct
+test-show-details: direct
 
 allow-newer:
 	active:base,

--- a/ghcide.cabal
+++ b/ghcide.cabal
@@ -338,7 +338,7 @@ test-suite ghcide-tests
         haskell-lsp-types,
         network-uri,
         lens,
-        lsp-test >= 0.11.0.5 && < 0.12,
+        lsp-test >= 0.11.0.6 && < 0.12,
         optparse-applicative,
         process,
         QuickCheck,

--- a/stack.yaml
+++ b/stack.yaml
@@ -5,7 +5,7 @@ extra-deps:
 - aeson-1.4.6.0
 - haskell-lsp-0.22.0.0
 - haskell-lsp-types-0.22.0.0
-- lsp-test-0.11.0.5
+- lsp-test-0.11.0.6
 - hie-bios-0.7.1@rev:2
 - implicit-hie-0.1.1.0
 - implicit-hie-cradle-0.2.0.1

--- a/stack810.yaml
+++ b/stack810.yaml
@@ -5,7 +5,7 @@ packages:
 extra-deps:
 - haskell-lsp-0.22.0.0
 - haskell-lsp-types-0.22.0.0
-- lsp-test-0.11.0.5
+- lsp-test-0.11.0.6
 - ghc-check-0.5.0.1
 - hie-bios-0.7.1
 

--- a/stack8101.yaml
+++ b/stack8101.yaml
@@ -5,7 +5,7 @@ packages:
 extra-deps:
 - haskell-lsp-0.22.0.0
 - haskell-lsp-types-0.22.0.0
-- lsp-test-0.11.0.2
+- lsp-test-0.11.0.6
 - ghc-check-0.5.0.1
 - hie-bios-0.7.1
 

--- a/stack88.yaml
+++ b/stack88.yaml
@@ -4,7 +4,7 @@ packages:
 extra-deps:
 - haskell-lsp-0.22.0.0
 - haskell-lsp-types-0.22.0.0
-- lsp-test-0.11.0.5
+- lsp-test-0.11.0.6
 - ghc-check-0.5.0.1
 - hie-bios-0.7.1
 - extra-1.7.2

--- a/test/exe/Main.hs
+++ b/test/exe/Main.hs
@@ -2258,7 +2258,6 @@ findDefinitionAndHoverTests = let
         yes    = Just -- test should run and pass
         broken = Just . (`xfail` "known broken")
         no = const Nothing -- don't run this test at all
-        brokenWin = Just . knownBrokenInWindows
 
 checkFileCompiles :: FilePath -> TestTree
 checkFileCompiles fp =
@@ -2396,7 +2395,7 @@ thTests =
   testGroup
     "TemplateHaskell"
     [ -- Test for https://github.com/digital-asset/ghcide/pull/212
-      knownBrokenInWindows $ testSessionWait "load" $ do
+      testSessionWait "load" $ do
         let sourceA =
               T.unlines
                 [ "{-# LANGUAGE PackageImports #-}",
@@ -3146,7 +3145,7 @@ simpleMultiTest = testCase "simple-multi-test" $ withoutStackEnv $ runWithExtraF
 
 -- Like simpleMultiTest but open the files in the other order
 simpleMultiTest2 :: TestTree
-simpleMultiTest2 = knownBrokenInWindows $ testCase "simple-multi-test2" $ withoutStackEnv $ runWithExtraFiles "multi" $ \dir -> do
+simpleMultiTest2 = testCase "simple-multi-test2" $ withoutStackEnv $ runWithExtraFiles "multi" $ \dir -> do
     let aPath = dir </> "a/A.hs"
         bPath = dir </> "b/B.hs"
     bSource <- liftIO $ readFileUtf8 bPath

--- a/test/exe/Main.hs
+++ b/test/exe/Main.hs
@@ -2292,7 +2292,7 @@ pluginSimpleTests =
 
 pluginParsedResultTests :: TestTree
 pluginParsedResultTests =
-  testSessionWait "parsedResultAction plugin" $ do
+  knownBrokenInWindowsAndGHC10 $ testSessionWait "parsedResultAction plugin" $ do
     let content =
           T.unlines
             [ "{-# LANGUAGE DuplicateRecordFields, TypeApplications, FlexibleContexts, DataKinds, MultiParamTypeClasses, TypeSynonymInstances, FlexibleInstances #-}"

--- a/test/exe/Main.hs
+++ b/test/exe/Main.hs
@@ -2269,7 +2269,7 @@ checkFileCompiles fp =
 
 pluginSimpleTests :: TestTree
 pluginSimpleTests =
-  knownBrokenInWindowsAndGHC10 $ testSessionWait "simple plugin" $ do
+  ignoreInWindowsAndGHCGreaterThan88 $ testSessionWait "simple plugin" $ do
     let content =
           T.unlines
             [ "{-# OPTIONS_GHC -fplugin GHC.TypeLits.KnownNat.Solver #-}"
@@ -2292,7 +2292,7 @@ pluginSimpleTests =
 
 pluginParsedResultTests :: TestTree
 pluginParsedResultTests =
-  knownBrokenInWindowsAndGHC10 $ testSessionWait "parsedResultAction plugin" $ do
+  ignoreInWindowsAndGHCGreaterThan88 $ testSessionWait "parsedResultAction plugin" $ do
     let content =
           T.unlines
             [ "{-# LANGUAGE DuplicateRecordFields, TypeApplications, FlexibleContexts, DataKinds, MultiParamTypeClasses, TypeSynonymInstances, FlexibleInstances #-}"
@@ -2954,12 +2954,12 @@ expectFailCabal = expectFailBecause
 ignoreInWindowsBecause :: String -> TestTree -> TestTree
 ignoreInWindowsBecause = if isWindows then ignoreTestBecause else flip const
 
-knownBrokenInWindowsAndGHC10 :: TestTree -> TestTree
-#if MIN_GHC_API_VERSION(8,10,0)
-knownBrokenInWindowsAndGHC10 = expectFailWindows "known broken in windows for ghc-8.10"
-  where expectFailWindows = if isWindows then expectFailBecause else flip const
+ignoreInWindowsAndGHCGreaterThan88 :: TestTree -> TestTree
+#if MIN_GHC_API_VERSION(8,8,4)
+ignoreInWindowsAndGHCGreaterThan88 =
+    ignoreInWindowsBecause "tests are unreliable for windows and ghc greater than 8.8"
 #else
-knownBrokenInWindowsAndGHC10 = id
+ignoreInWindowsAndGHCGreaterThan88 = id
 #endif
 
 data Expect

--- a/test/exe/Main.hs
+++ b/test/exe/Main.hs
@@ -2177,7 +2177,7 @@ findDefinitionAndHoverTests = let
   aaaL14 = Position 18 20  ;  aaa    = [mkR  11  0   11  3]
   dcL7   = Position 11 11  ;  tcDC   = [mkR   7 23    9 16]
   dcL12  = Position 16 11  ;
-  xtcL5  = Position  9 11  ;  xtc    = [ExpectExternFail,   ExpectHoverText ["Int", "Defined in 'GHC.Types'"]]
+  xtcL5  = Position  9 11  ;  xtc    = [ExpectExternFail,   ExpectHoverText ["Int", "Defined in ", "GHC.Types"]]
   tcL6   = Position 10 11  ;  tcData = [mkR   7  0    9 16, ExpectHoverText ["TypeConstructor", "GotoHover.hs:8:1"]]
   vvL16  = Position 20 12  ;  vv     = [mkR  20  4   20  6]
   opL16  = Position 20 15  ;  op     = [mkR  21  2   21  4]

--- a/test/exe/Main.hs
+++ b/test/exe/Main.hs
@@ -2303,7 +2303,7 @@ pluginParsedResultTests =
             , "display c = c.name"
             ]
     _ <- createDoc "Testing.hs" "haskell" content
-    expectNoMoreDiagnostics 1
+    expectNoMoreDiagnostics 2
 
 cppTests :: TestTree
 cppTests =

--- a/test/exe/Main.hs
+++ b/test/exe/Main.hs
@@ -2308,7 +2308,7 @@ pluginParsedResultTests =
 cppTests :: TestTree
 cppTests =
   testGroup "cpp"
-    [ knownBrokenInWindows $ testCase "cpp-error" $ do
+    [ ignoreInWindowsBecause "Throw a lsp session time out in windows for ghc-8.8" $ testCase "cpp-error" $ do
         let content =
               T.unlines
                 [ "{-# LANGUAGE CPP #-}",
@@ -2950,6 +2950,9 @@ expectFailCabal _ = id
 #else
 expectFailCabal = expectFailBecause
 #endif
+
+ignoreInWindowsBecause :: String -> TestTree -> TestTree
+ignoreInWindowsBecause = if isWindows then ignoreTestBecause else flip const
 
 expectFailWindows :: String -> TestTree -> TestTree
 expectFailWindows = if isWindows then expectFailBecause else flip const

--- a/test/exe/Main.hs
+++ b/test/exe/Main.hs
@@ -2269,7 +2269,7 @@ checkFileCompiles fp =
 
 pluginSimpleTests :: TestTree
 pluginSimpleTests =
-  ignoreInWindowsAndGHCGreaterThan88 $ testSessionWait "simple plugin" $ do
+  ignoreInWindowsAndGHCGreaterThan86 $ testSessionWait "simple plugin" $ do
     let content =
           T.unlines
             [ "{-# OPTIONS_GHC -fplugin GHC.TypeLits.KnownNat.Solver #-}"
@@ -2292,7 +2292,7 @@ pluginSimpleTests =
 
 pluginParsedResultTests :: TestTree
 pluginParsedResultTests =
-  ignoreInWindowsAndGHCGreaterThan88 $ testSessionWait "parsedResultAction plugin" $ do
+  ignoreInWindowsAndGHCGreaterThan86 $ testSessionWait "parsedResultAction plugin" $ do
     let content =
           T.unlines
             [ "{-# LANGUAGE DuplicateRecordFields, TypeApplications, FlexibleContexts, DataKinds, MultiParamTypeClasses, TypeSynonymInstances, FlexibleInstances #-}"
@@ -2954,12 +2954,12 @@ expectFailCabal = expectFailBecause
 ignoreInWindowsBecause :: String -> TestTree -> TestTree
 ignoreInWindowsBecause = if isWindows then ignoreTestBecause else flip const
 
-ignoreInWindowsAndGHCGreaterThan88 :: TestTree -> TestTree
-#if MIN_GHC_API_VERSION(8,8,4)
-ignoreInWindowsAndGHCGreaterThan88 =
-    ignoreInWindowsBecause "tests are unreliable for windows and ghc greater than 8.8"
+ignoreInWindowsAndGHCGreaterThan86 :: TestTree -> TestTree
+#if MIN_GHC_API_VERSION(8,8,1)
+ignoreInWindowsAndGHCGreaterThan86 =
+    ignoreInWindowsBecause "tests are unreliable for windows and ghc greater than 8.6.5"
 #else
-ignoreInWindowsAndGHCGreaterThan88 = id
+ignoreInWindowsAndGHCGreaterThan86 = id
 #endif
 
 data Expect

--- a/test/exe/Main.hs
+++ b/test/exe/Main.hs
@@ -2269,7 +2269,7 @@ checkFileCompiles fp =
 
 pluginSimpleTests :: TestTree
 pluginSimpleTests =
-  testSessionWait "simple plugin" $ do
+  knownBrokenInWindowsAndGHC10 $ testSessionWait "simple plugin" $ do
     let content =
           T.unlines
             [ "{-# OPTIONS_GHC -fplugin GHC.TypeLits.KnownNat.Solver #-}"
@@ -2292,7 +2292,7 @@ pluginSimpleTests =
 
 pluginParsedResultTests :: TestTree
 pluginParsedResultTests =
-  testSessionWait "parsedResultAction plugin" $ do
+  knownBrokenInWindowsAndGHC10 $ testSessionWait "parsedResultAction plugin" $ do
     let content =
           T.unlines
             [ "{-# LANGUAGE DuplicateRecordFields, TypeApplications, FlexibleContexts, DataKinds, MultiParamTypeClasses, TypeSynonymInstances, FlexibleInstances #-}"
@@ -2951,11 +2951,15 @@ expectFailCabal _ = id
 expectFailCabal = expectFailBecause
 #endif
 
-knownBrokenInWindows :: TestTree -> TestTree
-knownBrokenInWindows = expectFailWindows "known broken in windows"
-
 expectFailWindows :: String -> TestTree -> TestTree
 expectFailWindows = if isWindows then expectFailBecause else flip const
+
+knownBrokenInWindowsAndGHC10 :: TestTree -> TestTree
+#if MIN_GHC_API_VERSION(8,10,0)
+knownBrokenInWindowsAndGHC10 = expectFailWindows "known broken in windows for ghc-8.10"
+#else
+knownBrokenInWindowsAndGHC10 = id
+#endif
 
 data Expect
   = ExpectRange Range -- Both gotoDef and hover should report this range

--- a/test/exe/Main.hs
+++ b/test/exe/Main.hs
@@ -2292,7 +2292,7 @@ pluginSimpleTests =
 
 pluginParsedResultTests :: TestTree
 pluginParsedResultTests =
-  knownBrokenInWindowsAndGHC10 $ testSessionWait "parsedResultAction plugin" $ do
+  testSessionWait "parsedResultAction plugin" $ do
     let content =
           T.unlines
             [ "{-# LANGUAGE DuplicateRecordFields, TypeApplications, FlexibleContexts, DataKinds, MultiParamTypeClasses, TypeSynonymInstances, FlexibleInstances #-}"
@@ -2308,7 +2308,7 @@ pluginParsedResultTests =
 cppTests :: TestTree
 cppTests =
   testGroup "cpp"
-    [ ignoreInWindowsBecause "Throw a lsp session time out in windows for ghc-8.8" $ testCase "cpp-error" $ do
+    [ ignoreInWindowsBecause "Throw a lsp session time out in windows for ghc-8.8 and is broken for other versions" $ testCase "cpp-error" $ do
         let content =
               T.unlines
                 [ "{-# LANGUAGE CPP #-}",

--- a/test/exe/Main.hs
+++ b/test/exe/Main.hs
@@ -587,8 +587,9 @@ watchedFilesTests = testGroup "watched files"
       -- Expect 1 subscription: we only ever send one
       liftIO $ length watchedFileRegs @?= 1
 
-  , knownBrokenInWindows $ testSession' "non workspace file" $ \sessionDir -> do
-      liftIO $ writeFile (sessionDir </> "hie.yaml") "cradle: {direct: {arguments: [\"-i/tmp\", \"A\", \"WatchedFilesMissingModule\"]}}"
+  , testSession' "non workspace file" $ \sessionDir -> do
+      tmpDir <- liftIO getTemporaryDirectory
+      liftIO $ writeFile (sessionDir </> "hie.yaml") ("cradle: {direct: {arguments: [\"-i" <> tmpDir <> "\", \"A\", \"WatchedFilesMissingModule\"]}}")
       _doc <- createDoc "A.hs" "haskell" "{-# LANGUAGE NoImplicitPrelude#-}\nmodule A where\nimport WatchedFilesMissingModule"
       watchedFileRegs <- getWatchedFilesSubscriptionsUntil @PublishDiagnosticsNotification
 

--- a/test/exe/Main.hs
+++ b/test/exe/Main.hs
@@ -2954,12 +2954,10 @@ expectFailCabal = expectFailBecause
 ignoreInWindowsBecause :: String -> TestTree -> TestTree
 ignoreInWindowsBecause = if isWindows then ignoreTestBecause else flip const
 
-expectFailWindows :: String -> TestTree -> TestTree
-expectFailWindows = if isWindows then expectFailBecause else flip const
-
 knownBrokenInWindowsAndGHC10 :: TestTree -> TestTree
 #if MIN_GHC_API_VERSION(8,10,0)
 knownBrokenInWindowsAndGHC10 = expectFailWindows "known broken in windows for ghc-8.10"
+  where expectFailWindows = if isWindows then expectFailBecause else flip const
 #else
 knownBrokenInWindowsAndGHC10 = id
 #endif

--- a/test/exe/Main.hs
+++ b/test/exe/Main.hs
@@ -284,16 +284,17 @@ diagnosticTests = testGroup "diagnostics"
       let contentA = T.unlines [ "module ModuleA where" ]
       _ <- createDoc "ModuleA.hs" "haskell" contentA
       expectDiagnostics [("ModuleB.hs", [])]
-  , knownBrokenInWindows $ testSessionWait "add missing module (non workspace)" $ do
+  , testSessionWait "add missing module (non workspace)" $ do
+      tmpDir <- liftIO getTemporaryDirectory
       let contentB = T.unlines
             [ "module ModuleB where"
             , "import ModuleA ()"
             ]
-      _ <- createDoc "/tmp/ModuleB.hs" "haskell" contentB
-      expectDiagnostics [("/tmp/ModuleB.hs", [(DsError, (1, 7), "Could not find module")])]
+      _ <- createDoc (tmpDir </> "ModuleB.hs") "haskell" contentB
+      expectDiagnostics [(tmpDir </> "ModuleB.hs", [(DsError, (1, 7), "Could not find module")])]
       let contentA = T.unlines [ "module ModuleA where" ]
-      _ <- createDoc "/tmp/ModuleA.hs" "haskell" contentA
-      expectDiagnostics [("/tmp/ModuleB.hs", [])]
+      _ <- createDoc (tmpDir </> "ModuleA.hs") "haskell" contentA
+      expectDiagnostics [(tmpDir </> "ModuleB.hs", [])]
   , testSessionWait "cyclic module dependency" $ do
       let contentA = T.unlines
             [ "module ModuleA where"
@@ -2186,7 +2187,7 @@ findDefinitionAndHoverTests = let
   xvL20  = Position 24  8  ;  xvMsg  = [ExpectExternFail,   ExpectHoverText ["pack", ":: String -> Text", "Data.Text"]]
   clL23  = Position 27 11  ;  cls    = [mkR  25  0   26 20, ExpectHoverText ["MyClass", "GotoHover.hs:26:1"]]
   clL25  = Position 29  9
-  eclL15 = Position 19  8  ;  ecls   = [ExpectExternFail, ExpectHoverText ["Num", "Defined in 'GHC.Num'"]]
+  eclL15 = Position 19  8  ;  ecls   = [ExpectExternFail, ExpectHoverText ["Num", "Defined in ", "GHC.Num"]]
   dnbL29 = Position 33 18  ;  dnb    = [ExpectHoverText [":: ()"],   mkR  33 12   33 21]
   dnbL30 = Position 34 23
   lcbL33 = Position 37 26  ;  lcb    = [ExpectHoverText [":: Char"], mkR  37 26   37 27]


### PR DESCRIPTION
* Failing tests are marked with `knownBrokenInWindows` until they get fixed: see #474
* Enable test suite in azure
* It needs a `lsp-test` hackage release with the fix to avoid hangs in windows (/cc @bubba)