### PR TITLE
Memory info and more details in opentelemetry

### DIFF
--- a/bench/lib/Experiments.hs
+++ b/bench/lib/Experiments.hs
@@ -147,7 +147,7 @@ data Config = Config
   { verbosity :: !Verbosity,
     -- For some reason, the Shake profile files are truncated and won't load
     shakeProfiling :: !(Maybe FilePath),
-    otProfiling :: !(Maybe FilePath),
+    otMemoryProfiling :: !(Maybe FilePath),
     outputCSV :: !FilePath,
     buildTool :: !CabalStack,
     ghcideOptions :: ![String],
@@ -240,7 +240,7 @@ runBenchmarks allBenchmarks = do
                    | b <- allBenchmarks
                    , select b ]
 
-  whenJust (otProfiling ?config) $ \eventlogDir ->
+  whenJust (otMemoryProfiling ?config) $ \eventlogDir ->
       createDirectoryIfMissing True eventlogDir
 
   results <- forM benchmarks $ \b@Bench{name} ->
@@ -311,7 +311,7 @@ runBenchmarks allBenchmarks = do
           "+RTS",
           "-S" <> gcStats name
         ]
-          ++ case otProfiling ?config of
+          ++ case otMemoryProfiling ?config of
             Just dir -> ["-l", "-ol" ++ (dir </> (map (\c -> if c == ' ' then '-' else c) name) <.> "eventlog")]
             Nothing -> []
           ++ [ "-RTS" ]
@@ -320,7 +320,7 @@ runBenchmarks allBenchmarks = do
             [ ["--shake-profiling", path] | Just path <- [shakeProfiling ?config]
             ]
           ++ ["--verbose" | verbose ?config]
-          ++ if isJust (otProfiling ?config) then [ "--ot-profiling" ] else []
+          ++ if isJust (otMemoryProfiling ?config) then [ "--ot-memory-profiling" ] else []
     lspTestCaps =
       fullCaps {_window = Just $ WindowClientCapabilities $ Just True}
     conf =

--- a/docs/opentelemetry.md
+++ b/docs/opentelemetry.md
@@ -56,11 +56,11 @@ cabal install openetelemetry-extra
 3. `cd` into the directory containing the source you downloaded
 4. Build the `import-chrome` and `Tracy` libraries:
    ```sh
-   make -C profiler/build/unix
-   make -C import-chrome/build/unix
+   make -C profiler/build/unix release
+   make -C import-chrome/build/unix release
    ```
 5. Copy the binaries to your `$PATH`:
    ```sh
-   cp profiler/build/unix/Tracy-debug ~/.local/bin/Tracy
-   cp import-chrome/build/unix/import-chrome-debug ~/.local/bin/import-chrome
+   cp profiler/build/unix/Tracy-release ~/.local/bin/Tracy
+   cp import-chrome/build/unix/import-chrome-release ~/.local/bin/import-chrome
    ```

--- a/docs/opentelemetry.md
+++ b/docs/opentelemetry.md
@@ -1,0 +1,66 @@
+# Using opentelemetry
+
+`ghcide` has support for opentelemetry-based tracing. This allows for tracing
+the execution of the process, seeing when Shake rules fire and for how long they
+run, when LSP messages are received, and (currently WIP) measuring the memory
+occupancy of different objects in memory.
+
+## Capture opentlemetry data
+
+Capturing of opentelemetry data can be enabled by first building ghcide with eventlog support:
+
+```sh
+stack build --ghc-options -eventlog
+```
+
+Then, you can run `ghcide`, giving it a file to dump eventlog information into.
+
+```sh
+ghcide +RTS -l -ol ghcide.eventlog -RTS
+```
+
+You can also optionally enable reporting detailed memory data with `--ot-memory-profiling`
+
+```sh
+ghcide --ot-memory-profiling +RTS -l -ol ghcide.eventlog -RTS
+```
+
+*Note:* This option, while functional, is extremely slow. You will notice this because the memory graph in the output will have datapoints spaced apart by a couple of minutes.
+
+## Viewing with tracy
+
+After installing `opentelemetry-extra` and `tracy`, you can view the opentelementry output:
+
+```sh
+eventlog-to-tracy ghcide.eventlog
+```
+
+If everything has been set up correctly, this should open a tracy window with the tracing data you captured
+
+### Installing opentelemetry-extra
+
+This package includes a number of binaries for converting between the eventlog output and the formats that various opentelemetry viewers (like tracy) can display:
+
+```sh
+cabal install openetelemetry-extra
+```
+
+
+
+### Building tracy
+
+1. Install the dependencies: `pkg-config, glfw, freetype, capstone, GTK3`, along
+   with their header files (`<pkgname>-dev` on most distros. On Arch the header
+   files are included with the normal packages).
+2. Download tracy from https://github.com/wolfpld/tracy
+3. `cd` into the directory containing the source you downloaded
+4. Build the `import-chrome` and `Tracy` libraries:
+   ```sh
+   make -C profiler/build/unix
+   make -C import-chrome/build/unix
+   ```
+5. Copy the binaries to your `$PATH`:
+   ```sh
+   cp profiler/build/unix/Tracy-debug ~/.local/bin/Tracy
+   cp import-chrome/build/unix/import-chrome-debug ~/.local/bin/import-chrome
+   ```

--- a/docs/opentelemetry.md
+++ b/docs/opentelemetry.md
@@ -49,7 +49,7 @@ cabal install openetelemetry-extra
 
 ### Building tracy
 
-1. Install the dependencies: `pkg-config, glfw, freetype, capstone, GTK3`, along
+1. Install the dependencies: `pkg-config` and `glfw, freetype, capstone, GTK3`, along
    with their header files (`<pkgname>-dev` on most distros. On Arch the header
    files are included with the normal packages).
 2. Download tracy from https://github.com/wolfpld/tracy

--- a/exe/Arguments.hs
+++ b/exe/Arguments.hs
@@ -12,6 +12,7 @@ data Arguments = Arguments
     ,argFiles :: [FilePath]
     ,argsVersion :: Bool
     ,argsShakeProfiling :: Maybe FilePath
+    ,argsOTProfiling :: Bool
     ,argsTesting :: Bool
     ,argsThreads :: Int
     ,argsVerbose :: Bool
@@ -32,6 +33,7 @@ arguments = Arguments
       <*> many (argument str (metavar "FILES/DIRS..."))
       <*> switch (long "version" <> help "Show ghcide and GHC versions")
       <*> optional (strOption $ long "shake-profiling" <> metavar "DIR" <> help "Dump profiling reports to this directory")
+      <*> switch (long "ot-profiling" <> help "Record OpenTelemetry info to the eventlog. Needs the -l RTS flag to have an effect")
       <*> switch (long "test" <> help "Enable additional lsp messages used by the testsuite")
       <*> option auto (short 'j' <> help "Number of threads (0: automatic)" <> metavar "NUM" <> value 0 <> showDefault)
       <*> switch (long "verbose" <> help "Include internal events in logging output")

--- a/exe/Arguments.hs
+++ b/exe/Arguments.hs
@@ -12,7 +12,7 @@ data Arguments = Arguments
     ,argFiles :: [FilePath]
     ,argsVersion :: Bool
     ,argsShakeProfiling :: Maybe FilePath
-    ,argsOTProfiling :: Bool
+    ,argsOTMemoryProfiling :: Bool
     ,argsTesting :: Bool
     ,argsThreads :: Int
     ,argsVerbose :: Bool
@@ -33,7 +33,7 @@ arguments = Arguments
       <*> many (argument str (metavar "FILES/DIRS..."))
       <*> switch (long "version" <> help "Show ghcide and GHC versions")
       <*> optional (strOption $ long "shake-profiling" <> metavar "DIR" <> help "Dump profiling reports to this directory")
-      <*> switch (long "ot-profiling" <> help "Record OpenTelemetry info to the eventlog. Needs the -l RTS flag to have an effect")
+      <*> switch (long "ot-memory-profiling" <> help "Record OpenTelemetry info to the eventlog. Needs the -l RTS flag to have an effect")
       <*> switch (long "test" <> help "Enable additional lsp messages used by the testsuite")
       <*> option auto (short 'j' <> help "Number of threads (0: automatic)" <> metavar "NUM" <> value 0 <> showDefault)
       <*> switch (long "verbose" <> help "Include internal events in logging output")

--- a/exe/Main.hs
+++ b/exe/Main.hs
@@ -104,13 +104,13 @@ main = do
             sessionLoader <- loadSession $ fromMaybe dir rootPath
             config <- fromMaybe defaultLspConfig <$> getConfig
             let options = (defaultIdeOptions sessionLoader)
-                    { optReportProgress = clientSupportsProgress caps
-                    , optShakeProfiling = argsShakeProfiling
-                    , optOTProfiling    = IdeOTProfiling argsOTProfiling
-                    , optTesting        = IdeTesting argsTesting
-                    , optThreads        = argsThreads
-                    , optCheckParents   = checkParents config
-                    , optCheckProject   = checkProject config
+                    { optReportProgress    = clientSupportsProgress caps
+                    , optShakeProfiling    = argsShakeProfiling
+                    , optOTMemoryProfiling = IdeOTMemoryProfiling argsOTMemoryProfiling
+                    , optTesting           = IdeTesting argsTesting
+                    , optThreads           = argsThreads
+                    , optCheckParents      = checkParents config
+                    , optCheckProject      = checkProject config
                     }
                 logLevel = if argsVerbose then minBound else Info
             debouncer <- newAsyncDebouncer

--- a/exe/Main.hs
+++ b/exe/Main.hs
@@ -106,6 +106,7 @@ main = do
             let options = (defaultIdeOptions sessionLoader)
                     { optReportProgress = clientSupportsProgress caps
                     , optShakeProfiling = argsShakeProfiling
+                    , optOTProfiling    = IdeOTProfiling argsOTProfiling
                     , optTesting        = IdeTesting argsTesting
                     , optThreads        = argsThreads
                     , optCheckParents   = checkParents config

--- a/ghcide.cabal
+++ b/ghcide.cabal
@@ -72,6 +72,7 @@ library
         utf8-string,
         hslogger,
         opentelemetry >=0.6.0,
+        ghc-datasize ==0.3
     if flag(ghc-lib)
       build-depends:
         ghc-lib >= 8.8,

--- a/ghcide.cabal
+++ b/ghcide.cabal
@@ -72,7 +72,7 @@ library
         utf8-string,
         hslogger,
         opentelemetry >=0.6.0,
-        ghc-datasize ==0.3
+        heapsize ==0.1
     if flag(ghc-lib)
       build-depends:
         ghc-lib >= 8.8,

--- a/ghcide.cabal
+++ b/ghcide.cabal
@@ -71,7 +71,7 @@ library
         unordered-containers >= 0.2.10.0,
         utf8-string,
         hslogger,
-        opentelemetry >=0.6.0,
+        opentelemetry >=0.6.1,
         heapsize ==0.1
     if flag(ghc-lib)
       build-depends:

--- a/ghcide.cabal
+++ b/ghcide.cabal
@@ -167,6 +167,7 @@ library
         Development.IDE.Core.Compile
         Development.IDE.Core.Preprocessor
         Development.IDE.Core.FileExists
+        Development.IDE.Core.Tracing
         Development.IDE.GHC.CPP
         Development.IDE.GHC.Orphans
         Development.IDE.GHC.Warnings

--- a/ghcide.cabal
+++ b/ghcide.cabal
@@ -70,7 +70,8 @@ library
         transformers,
         unordered-containers >= 0.2.10.0,
         utf8-string,
-        hslogger
+        hslogger,
+        opentelemetry >=0.6.0,
     if flag(ghc-lib)
       build-depends:
         ghc-lib >= 8.8,

--- a/src/Development/IDE/Core/Shake.hs
+++ b/src/Development/IDE/Core/Shake.hs
@@ -445,6 +445,9 @@ shakeOpen getLspId eventer withProgress withIndefiniteProgress logger debouncer
     initSession <- newSession shakeExtras shakeDb []
     shakeSession <- newMVar initSession
     let ideState = IdeState{..}
+
+    startTelemetry "Values map" (state shakeExtras)
+
     return ideState
     where
         -- The progress thread is a state machine with two states:

--- a/src/Development/IDE/Core/Shake.hs
+++ b/src/Development/IDE/Core/Shake.hs
@@ -1193,7 +1193,7 @@ startTelemetry shakeExtras = do
         mapBytesInstrument <- mkValueObserver ("value map size_bytes")
         mapCountInstrument <- mkValueObserver ("values map count")
 
-        _ <- regularly 10000 $ -- 100 times/s
+        _ <- regularly 50000 $ -- 100 times/s
             withSpan_ "Measure length" $
             readVar stateRef
             >>= observe mapCountInstrument . length

--- a/src/Development/IDE/Core/Shake.hs
+++ b/src/Development/IDE/Core/Shake.hs
@@ -118,7 +118,9 @@ import Control.Monad.IO.Class
 import Control.Monad.Reader
 import Control.Monad.Trans.Maybe
 import Data.Traversable
+import Text.Printf
 import Data.Hashable
+import Development.IDE.Core.Tracing
 
 import Data.IORef
 import NameCache
@@ -849,7 +851,7 @@ defineEarlyCutoff
     :: IdeRule k v
     => (k -> NormalizedFilePath -> Action (Maybe BS.ByteString, IdeResult v))
     -> Rules ()
-defineEarlyCutoff op = addBuiltinRule noLint noIdentity $ \(Q (key, file)) (old :: Maybe BS.ByteString) mode -> do
+defineEarlyCutoff op = addBuiltinRule noLint noIdentity $ \(Q (key, file)) (old :: Maybe BS.ByteString) mode -> otTracedAction key file $ do
     extras@ShakeExtras{state, inProgress} <- getShakeExtras
     -- don't do progress for GetFileExists, as there are lots of non-nodes for just that one key
     (if show key == "GetFileExists" then id else withProgressVar inProgress file) $ do

--- a/src/Development/IDE/Core/Shake.hs
+++ b/src/Development/IDE/Core/Shake.hs
@@ -1184,9 +1184,9 @@ updatePositionMapping IdeState{shakeExtras = ShakeExtras{positionMapping}} Versi
 
 startTelemetry :: ShakeExtras -> IO ()
 startTelemetry shakeExtras = do
-    IdeOptions{ optOTProfiling = (IdeOTProfiling otProfilingEnabled) } <- getIdeOptionsIO shakeExtras
+    IdeOptions{ optOTMemoryProfiling = (IdeOTMemoryProfiling otMemoryProfilingEnabled) } <- getIdeOptionsIO shakeExtras
 
-    when otProfilingEnabled $ do
+    when otMemoryProfilingEnabled $ do
         let ShakeExtras { state=stateRef } = shakeExtras
         instrumentFor <- getInstrumentCached <$> (newVar HMap.empty)
 

--- a/src/Development/IDE/Core/Shake.hs
+++ b/src/Development/IDE/Core/Shake.hs
@@ -446,7 +446,7 @@ shakeOpen getLspId eventer withProgress withIndefiniteProgress logger debouncer
     shakeSession <- newMVar initSession
     let ideState = IdeState{..}
 
-    startTelemetry "Values map" (state shakeExtras)
+    startTelemetry "Values map" (state shakeExtras) =<< (optOTProfiling <$> getIdeOptionsIO shakeExtras)
 
     return ideState
     where

--- a/src/Development/IDE/Core/Shake.hs
+++ b/src/Development/IDE/Core/Shake.hs
@@ -1197,7 +1197,7 @@ startTelemetry shakeExtras = do
             readVar stateRef
             >>= observe mapCountInstrument . length
 
-        _ <- regularly 500000 $
+        _ <- regularly 0 $
             withSpan_ "Measure Memory" $ do
             performGC
             values <- readVar stateRef

--- a/src/Development/IDE/Core/Tracing.hs
+++ b/src/Development/IDE/Core/Tracing.hs
@@ -1,17 +1,35 @@
-module Development.IDE.Core.Tracing (otTraced, otTracedAction) where
+module Development.IDE.Core.Tracing where
 
+import           Control.Concurrent
+import           Control.Exception
+import           Control.Monad
 import           Development.Shake
-import qualified Data.ByteString.Char8         as BS
 import           Language.Haskell.LSP.Types
 import           OpenTelemetry.Eventlog
-import           Control.Exception
+import qualified Data.ByteString.Char8         as BS
+import           Control.Concurrent.Extra
 import           Control.Concurrent.Async
-import           Control.Concurrent
-import           Control.Monad
+import GHC.DataSize
+import qualified Data.HashMap.Strict as HMap
+import           Data.Functor
 
 -- | Trace an action using OpenTelemetry. Adds various useful info into tags in the OpenTelemetry span.
 otTraced :: BS.ByteString -> IO a -> IO a
 otTraced name act = bracket (beginSpan name) endSpan (const act)
+
+-- | Trace a handler using OpenTelemetry. Adds various useful info into tags in the OpenTelemetry span.
+otTracedHandler
+    :: String -- ^ Message type
+    -> String -- ^ Message label
+    -> IO a
+    -> IO a
+otTracedHandler requestType label act =
+  let !name =
+        if null label
+          then BS.pack requestType
+          else BS.pack (requestType <> ":" <> show label)
+   -- Add an event so all requests can be quickly seen in the viewer without searching
+   in withSpan name (\sp -> addEvent sp "" (name <> " received") >> act)
 
 -- | Trace a Shake action using opentelemetry.
 otTracedAction
@@ -22,12 +40,29 @@ otTracedAction
     -> Action a
 otTracedAction key file act = actionBracket
     (do
-        sp <- beginSpan (show key)
+        sp <- beginSpan (BS.pack (show key))
         setTag sp "File" (BS.pack $ fromNormalizedFilePath file)
         return sp
     )
     endSpan
     (const act)
 
+startTelemetry :: Show k => String -> Var (HMap.HashMap k v) -> IO ()
+startTelemetry name valuesRef = do
+  mapBytesInstrument <- mkValueObserver (BS.pack name <> " size_bytes")
+  mapCountInstrument <- mkValueObserver (BS.pack name <> " count")
+
+  _ <- regularly 500000 $
+    withSpan_ "Measure length" $
+      readVar valuesRef
+      <&> length
+      >>= observe mapCountInstrument
+  _ <- regularly 500000 $
+    withSpan_ "Measure Memory" $
+      readVar valuesRef
+      >>= recursiveSize
+      >>= observe mapBytesInstrument
+  return ()
+
 regularly :: Int -> IO () -> IO (Async ())
-regularly delay act = async $ forever (threadDelay delay >> act)
+regularly delay act = async $ forever (act >> threadDelay delay)

--- a/src/Development/IDE/Core/Tracing.hs
+++ b/src/Development/IDE/Core/Tracing.hs
@@ -10,7 +10,7 @@ import           Control.Concurrent
 import           Control.Monad
 
 -- | Trace an action using OpenTelemetry. Adds various useful info into tags in the OpenTelemetry span.
-otTraced :: String -> IO a -> IO a
+otTraced :: BS.ByteString -> IO a -> IO a
 otTraced name act = bracket (beginSpan name) endSpan (const act)
 
 -- | Trace a Shake action using opentelemetry.

--- a/src/Development/IDE/Core/Tracing.hs
+++ b/src/Development/IDE/Core/Tracing.hs
@@ -1,0 +1,33 @@
+module Development.IDE.Core.Tracing (otTraced, otTracedAction) where
+
+import           Development.Shake
+import qualified Data.ByteString.Char8         as BS
+import           Language.Haskell.LSP.Types
+import           OpenTelemetry.Eventlog
+import           Control.Exception
+import           Control.Concurrent.Async
+import           Control.Concurrent
+import           Control.Monad
+
+-- | Trace an action using OpenTelemetry. Adds various useful info into tags in the OpenTelemetry span.
+otTraced :: String -> IO a -> IO a
+otTraced name act = bracket (beginSpan name) endSpan (const act)
+
+-- | Trace a Shake action using opentelemetry.
+otTracedAction
+    :: Show k
+    => k -- ^ The Action's Key
+    -> NormalizedFilePath -- ^ Path to the file the action was run for
+    -> Action a -- ^ The action
+    -> Action a
+otTracedAction key file act = actionBracket
+    (do
+        sp <- beginSpan (show key)
+        setTag sp "File" (BS.pack $ fromNormalizedFilePath file)
+        return sp
+    )
+    endSpan
+    (const act)
+
+regularly :: Int -> IO () -> IO (Async ())
+regularly delay act = async $ forever (threadDelay delay >> act)

--- a/src/Development/IDE/Core/Tracing.hs
+++ b/src/Development/IDE/Core/Tracing.hs
@@ -10,7 +10,7 @@ import           OpenTelemetry.Eventlog
 import qualified Data.ByteString.Char8         as BS
 import           Control.Concurrent.Extra
 import           Control.Concurrent.Async
-import GHC.DataSize
+import           HeapSize
 import qualified Data.HashMap.Strict as HMap
 import           Data.Functor
 import           System.Mem (performGC)

--- a/src/Development/IDE/Core/Tracing.hs
+++ b/src/Development/IDE/Core/Tracing.hs
@@ -1,4 +1,10 @@
-module Development.IDE.Core.Tracing where
+module Development.IDE.Core.Tracing
+    ( otTraced
+    , otTracedHandler
+    , otTracedAction
+    , startTelemetry
+    )
+where
 
 import           Control.Concurrent
 import           Control.Exception
@@ -59,8 +65,7 @@ startTelemetry name valuesRef (IdeOTProfiling True) = do
   _ <- regularly 10000 $ -- 100 times/s
     withSpan_ "Measure length" $
       readVar valuesRef
-      <&> length
-      >>= observe mapCountInstrument
+      >>= observe mapCountInstrument . length
   _ <- regularly 500000 $ -- 2 times/s (If it could run that fast)
     withSpan_ "Measure Memory" $
       readVar valuesRef

--- a/src/Development/IDE/LSP/HoverDefinition.hs
+++ b/src/Development/IDE/LSP/HoverDefinition.hs
@@ -15,6 +15,7 @@ module Development.IDE.LSP.HoverDefinition
 
 import           Development.IDE.Core.Rules
 import           Development.IDE.Core.Shake
+import           Development.IDE.Core.Tracing
 import           Development.IDE.LSP.Server
 import           Development.IDE.Types.Location
 import           Development.IDE.Types.Logger

--- a/src/Development/IDE/LSP/HoverDefinition.hs
+++ b/src/Development/IDE/LSP/HoverDefinition.hs
@@ -24,6 +24,7 @@ import           Language.Haskell.LSP.Messages
 import           Language.Haskell.LSP.Types
 
 import qualified Data.Text as T
+import qualified Data.Text.Encoding as TE
 
 gotoDefinition :: IdeState -> TextDocumentPositionParams -> IO (Either ResponseError LocationResponseParams)
 hover          :: IdeState -> TextDocumentPositionParams -> IO (Either ResponseError (Maybe Hover))

--- a/src/Development/IDE/LSP/HoverDefinition.hs
+++ b/src/Development/IDE/LSP/HoverDefinition.hs
@@ -15,7 +15,6 @@ module Development.IDE.LSP.HoverDefinition
 
 import           Development.IDE.Core.Rules
 import           Development.IDE.Core.Shake
-import           Development.IDE.Core.Tracing
 import           Development.IDE.LSP.Server
 import           Development.IDE.Types.Location
 import           Development.IDE.Types.Logger
@@ -24,7 +23,6 @@ import           Language.Haskell.LSP.Messages
 import           Language.Haskell.LSP.Types
 
 import qualified Data.Text as T
-import qualified Data.Text.Encoding as TE
 
 gotoDefinition :: IdeState -> TextDocumentPositionParams -> IO (Either ResponseError LocationResponseParams)
 hover          :: IdeState -> TextDocumentPositionParams -> IO (Either ResponseError (Maybe Hover))

--- a/src/Development/IDE/Types/Options.hs
+++ b/src/Development/IDE/Types/Options.hs
@@ -15,6 +15,7 @@ module Development.IDE.Types.Options
   , IdeReportProgress(..)
   , IdeDefer(..)
   , IdeTesting(..)
+  , IdeOTProfiling(..)
   , clientSupportsProgress
   , IdePkgLocationOptions(..)
   , defaultIdeOptions
@@ -68,6 +69,9 @@ data IdeOptions = IdeOptions
   -- meaning we keep everything in memory but the daml CLI compiler uses this for incremental builds.
   , optShakeProfiling :: Maybe FilePath
     -- ^ Set to 'Just' to create a directory of profiling reports.
+  , optOTProfiling :: IdeOTProfiling
+    -- ^ Whether to record profiling information with OpenTelemetry. You must
+    --   also enable the -l RTS flag for this to have any effect
   , optTesting :: IdeTesting
     -- ^ Whether to enable additional lsp messages used by the test suite for checking invariants
   , optReportProgress :: IdeReportProgress
@@ -137,6 +141,7 @@ data IdePreprocessedSource = IdePreprocessedSource
 newtype IdeReportProgress = IdeReportProgress Bool
 newtype IdeDefer          = IdeDefer          Bool
 newtype IdeTesting        = IdeTesting        Bool
+newtype IdeOTProfiling    = IdeOTProfiling    Bool
 
 clientSupportsProgress :: LSP.ClientCapabilities -> IdeReportProgress
 clientSupportsProgress caps = IdeReportProgress $ Just True ==
@@ -151,6 +156,7 @@ defaultIdeOptions session = IdeOptions
     ,optThreads = 0
     ,optShakeFiles = Nothing
     ,optShakeProfiling = Nothing
+    ,optOTProfiling = IdeOTProfiling False
     ,optReportProgress = IdeReportProgress False
     ,optLanguageSyntax = "haskell"
     ,optNewColonConvention = False

--- a/src/Development/IDE/Types/Options.hs
+++ b/src/Development/IDE/Types/Options.hs
@@ -15,7 +15,7 @@ module Development.IDE.Types.Options
   , IdeReportProgress(..)
   , IdeDefer(..)
   , IdeTesting(..)
-  , IdeOTProfiling(..)
+  , IdeOTMemoryProfiling(..)
   , clientSupportsProgress
   , IdePkgLocationOptions(..)
   , defaultIdeOptions
@@ -69,7 +69,7 @@ data IdeOptions = IdeOptions
   -- meaning we keep everything in memory but the daml CLI compiler uses this for incremental builds.
   , optShakeProfiling :: Maybe FilePath
     -- ^ Set to 'Just' to create a directory of profiling reports.
-  , optOTProfiling :: IdeOTProfiling
+  , optOTMemoryProfiling :: IdeOTMemoryProfiling
     -- ^ Whether to record profiling information with OpenTelemetry. You must
     --   also enable the -l RTS flag for this to have any effect
   , optTesting :: IdeTesting
@@ -138,10 +138,10 @@ data IdePreprocessedSource = IdePreprocessedSource
     -- ^ New parse tree emitted by the preprocessor.
   }
 
-newtype IdeReportProgress = IdeReportProgress Bool
-newtype IdeDefer          = IdeDefer          Bool
-newtype IdeTesting        = IdeTesting        Bool
-newtype IdeOTProfiling    = IdeOTProfiling    Bool
+newtype IdeReportProgress    = IdeReportProgress Bool
+newtype IdeDefer             = IdeDefer          Bool
+newtype IdeTesting           = IdeTesting        Bool
+newtype IdeOTMemoryProfiling = IdeOTMemoryProfiling    Bool
 
 clientSupportsProgress :: LSP.ClientCapabilities -> IdeReportProgress
 clientSupportsProgress caps = IdeReportProgress $ Just True ==
@@ -156,7 +156,7 @@ defaultIdeOptions session = IdeOptions
     ,optThreads = 0
     ,optShakeFiles = Nothing
     ,optShakeProfiling = Nothing
-    ,optOTProfiling = IdeOTProfiling False
+    ,optOTMemoryProfiling = IdeOTMemoryProfiling False
     ,optReportProgress = IdeReportProgress False
     ,optLanguageSyntax = "haskell"
     ,optNewColonConvention = False

--- a/stack.yaml
+++ b/stack.yaml
@@ -21,8 +21,7 @@ extra-deps:
 - extra-1.7.2
 - opentelemetry-0.6.1
 - opentelemetry-extra-0.6.1
-- git: https://github.com/mpardalos/heapsize.git
-  commit: e6d791eadeb97920d6697627de026e996465850d
+- heapsize-0.1
 nix:
   packages: [zlib]
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -19,7 +19,9 @@ extra-deps:
 - tasty-rerun-1.1.17
 - ghc-check-0.5.0.1
 - extra-1.7.2
-
+- opentelemetry-0.4.2
+- git: https://github.com/mpardalos/heapsize.git
+  commit: e6d791eadeb97920d6697627de026e996465850d
 nix:
   packages: [zlib]
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -19,7 +19,8 @@ extra-deps:
 - tasty-rerun-1.1.17
 - ghc-check-0.5.0.1
 - extra-1.7.2
-- opentelemetry-0.4.2
+- opentelemetry-0.6.1
+- opentelemetry-extra-0.6.1
 - git: https://github.com/mpardalos/heapsize.git
   commit: e6d791eadeb97920d6697627de026e996465850d
 nix:

--- a/stack810.yaml
+++ b/stack810.yaml
@@ -12,8 +12,8 @@ extra-deps:
 - opentelemetry-extra-0.6.0
 - ghc-events-0.13.0
 - ghc-trace-events-0.1.2.1
-- git: https://github.com/mpardalos/ghc-datasize.git
-  commit: e4f4829c8f6e2430455e73b32d499e856c4ff58f
+- git: https://github.com/mpardalos/heapsize.git
+  commit: e6d791eadeb97920d6697627de026e996465850d
 
 # not yet in stackage
 - Chart-diagrams-1.9.3

--- a/stack810.yaml
+++ b/stack810.yaml
@@ -12,8 +12,7 @@ extra-deps:
 - opentelemetry-extra-0.6.1
 - ghc-events-0.13.0
 - ghc-trace-events-0.1.2.1
-- git: https://github.com/mpardalos/heapsize.git
-  commit: e6d791eadeb97920d6697627de026e996465850d
+- heapsize-0.1
 
 # not yet in stackage
 - Chart-diagrams-1.9.3

--- a/stack810.yaml
+++ b/stack810.yaml
@@ -8,8 +8,8 @@ extra-deps:
 - lsp-test-0.11.0.5
 - ghc-check-0.5.0.1
 - hie-bios-0.7.1
-- opentelemetry-0.6.0
-- opentelemetry-extra-0.6.0
+- opentelemetry-0.6.1
+- opentelemetry-extra-0.6.1
 - ghc-events-0.13.0
 - ghc-trace-events-0.1.2.1
 - git: https://github.com/mpardalos/heapsize.git

--- a/stack810.yaml
+++ b/stack810.yaml
@@ -8,6 +8,8 @@ extra-deps:
 - lsp-test-0.11.0.5
 - ghc-check-0.5.0.1
 - hie-bios-0.7.1
+- opentelemetry-0.6.0
+- opentelemetry-extra-0.6.0
 
 # not yet in stackage
 - Chart-diagrams-1.9.3

--- a/stack810.yaml
+++ b/stack810.yaml
@@ -10,6 +10,10 @@ extra-deps:
 - hie-bios-0.7.1
 - opentelemetry-0.6.0
 - opentelemetry-extra-0.6.0
+- ghc-events-0.13.0
+- ghc-trace-events-0.1.2.1
+- git: https://github.com/mpardalos/ghc-datasize.git
+  commit: e4f4829c8f6e2430455e73b32d499e856c4ff58f
 
 # not yet in stackage
 - Chart-diagrams-1.9.3

--- a/stack88.yaml
+++ b/stack88.yaml
@@ -14,8 +14,8 @@ extra-deps:
 - opentelemetry-extra-0.6.0
 - ghc-events-0.13.0
 - ghc-trace-events-0.1.2.1
-- git: https://github.com/mpardalos/ghc-datasize.git
-  commit: e4f4829c8f6e2430455e73b32d499e856c4ff58f
+- git: https://github.com/mpardalos/heapsize.git
+  commit: e6d791eadeb97920d6697627de026e996465850d
 nix:
   packages: [zlib]
 

--- a/stack88.yaml
+++ b/stack88.yaml
@@ -12,6 +12,10 @@ extra-deps:
 - implicit-hie-cradle-0.2.0.0
 - opentelemetry-0.6.0
 - opentelemetry-extra-0.6.0
+- ghc-events-0.13.0
+- ghc-trace-events-0.1.2.1
+- git: https://github.com/mpardalos/ghc-datasize.git
+  commit: e4f4829c8f6e2430455e73b32d499e856c4ff58f
 nix:
   packages: [zlib]
 

--- a/stack88.yaml
+++ b/stack88.yaml
@@ -10,8 +10,8 @@ extra-deps:
 - extra-1.7.2
 - implicit-hie-0.1.1.0
 - implicit-hie-cradle-0.2.0.0
-- opentelemetry-0.6.0
-- opentelemetry-extra-0.6.0
+- opentelemetry-0.6.1
+- opentelemetry-extra-0.6.1
 - ghc-events-0.13.0
 - ghc-trace-events-0.1.2.1
 - git: https://github.com/mpardalos/heapsize.git

--- a/stack88.yaml
+++ b/stack88.yaml
@@ -14,8 +14,7 @@ extra-deps:
 - opentelemetry-extra-0.6.1
 - ghc-events-0.13.0
 - ghc-trace-events-0.1.2.1
-- git: https://github.com/mpardalos/heapsize.git
-  commit: e6d791eadeb97920d6697627de026e996465850d
+- heapsize-0.1
 nix:
   packages: [zlib]
 

--- a/stack88.yaml
+++ b/stack88.yaml
@@ -10,7 +10,8 @@ extra-deps:
 - extra-1.7.2
 - implicit-hie-0.1.1.0
 - implicit-hie-cradle-0.2.0.0
-
+- opentelemetry-0.6.0
+- opentelemetry-extra-0.6.0
 nix:
   packages: [zlib]
 


### PR DESCRIPTION
This patch adds the following information to opentelemetry traces:

* Number of entries in the "state" hashmap in ShakeExtras (Metric is called "values map size_bytes")
* Memory occupancy in that map. (This is currently very slow, and so sizes are only reported about once/minute)
* Trace of *all* LSP requests and notifications (as opposed to just those defined in HoverDefinition.hs, as before)

Other changes:
* Put opentelemetry tracing behind `--ot-profiling` flag
* Add `--ot-profiling` flag to benchmark to run ghcide with `--ot-profiling`
* Improve recording of heap_live_bytes in opentelemetry trace by running performGC every 0.5s (only with `--ot-profiling`)