### PR TITLE
Use object code for Template Haskell

### DIFF
--- a/session-loader/Development/IDE/Session.hs
+++ b/session-loader/Development/IDE/Session.hs
@@ -628,7 +628,7 @@ setOptions (ComponentOptions theOpts compRoot _) dflags = do
           -- also, it can confuse the interface stale check
           dontWriteHieFiles $
           setIgnoreInterfacePragmas $
-          -- setLinkerOptions $
+          setLinkerOptions $
           disableOptimisation $
           setUpTypedHoles $
           makeDynFlagsAbsolute compRoot dflags'
@@ -639,17 +639,15 @@ setOptions (ComponentOptions theOpts compRoot _) dflags = do
     return (final_df, targets)
 
 
-{-
 -- we don't want to generate object code so we compile to bytecode
 -- (HscInterpreted) which implies LinkInMemory
 -- HscInterpreted
 setLinkerOptions :: DynFlags -> DynFlags
 setLinkerOptions df = df {
     ghcLink   = LinkInMemory
-  , hscTarget = HscNothing
+  , hscTarget = HscAsm
   , ghcMode = CompManager
   }
--}
 
 setIgnoreInterfacePragmas :: DynFlags -> DynFlags
 setIgnoreInterfacePragmas df =

--- a/session-loader/Development/IDE/Session.hs
+++ b/session-loader/Development/IDE/Session.hs
@@ -118,9 +118,12 @@ loadSession dir = do
         -- files in the project so that `knownFiles` can learn about them and
         -- we can generate a complete module graph
     let extendKnownTargets newTargets = do
-          knownTargets <- forM newTargets $ \TargetDetails{..} -> do
-            found <- filterM (IO.doesFileExist . fromNormalizedFilePath) targetLocations
-            return (targetTarget, found)
+          knownTargets <- forM newTargets $ \TargetDetails{..} ->
+            case targetTarget of
+              TargetFile f -> pure (targetTarget, [f])
+              TargetModule _ -> do
+                found <- filterM (IO.doesFileExist . fromNormalizedFilePath) targetLocations
+                return (targetTarget, found)
           modifyVar_ knownTargetsVar $ traverseHashed $ \known -> do
             let known' = HM.unionWith (<>) known $ HM.fromList knownTargets
             when (known /= known') $

--- a/session-loader/Development/IDE/Session.hs
+++ b/session-loader/Development/IDE/Session.hs
@@ -501,6 +501,7 @@ setCacheDir logger prefix hscComponents comps dflags = do
     pure $ dflags
           & setHiDir cacheDir
           & setHieDir cacheDir
+          & setODir cacheDir
 
 
 renderCradleError :: NormalizedFilePath -> CradleError -> FileDiagnostic
@@ -624,7 +625,7 @@ setOptions (ComponentOptions theOpts compRoot _) dflags = do
           -- also, it can confuse the interface stale check
           dontWriteHieFiles $
           setIgnoreInterfacePragmas $
-          setLinkerOptions $
+          -- setLinkerOptions $
           disableOptimisation $
           setUpTypedHoles $
           makeDynFlagsAbsolute compRoot dflags'
@@ -635,6 +636,7 @@ setOptions (ComponentOptions theOpts compRoot _) dflags = do
     return (final_df, targets)
 
 
+{-
 -- we don't want to generate object code so we compile to bytecode
 -- (HscInterpreted) which implies LinkInMemory
 -- HscInterpreted
@@ -644,6 +646,7 @@ setLinkerOptions df = df {
   , hscTarget = HscNothing
   , ghcMode = CompManager
   }
+-}
 
 setIgnoreInterfacePragmas :: DynFlags -> DynFlags
 setIgnoreInterfacePragmas df =
@@ -656,6 +659,11 @@ setHiDir :: FilePath -> DynFlags -> DynFlags
 setHiDir f d =
     -- override user settings to avoid conflicts leading to recompilation
     d { hiDir      = Just f}
+
+setODir :: FilePath -> DynFlags -> DynFlags
+setODir f d =
+    -- override user settings to avoid conflicts leading to recompilation
+    d { objectDir = Just f}
 
 getCacheDir :: String -> [String] -> IO FilePath
 getCacheDir prefix opts = getXdgDirectory XdgCache (cacheDir </> prefix ++ "-" ++ opts_hash)

--- a/session-loader/Development/IDE/Session.hs
+++ b/session-loader/Development/IDE/Session.hs
@@ -645,7 +645,7 @@ setOptions (ComponentOptions theOpts compRoot _) dflags = do
 setLinkerOptions :: DynFlags -> DynFlags
 setLinkerOptions df = df {
     ghcLink   = LinkInMemory
-  , hscTarget = HscNothing
+  , hscTarget = HscAsm
   , ghcMode = CompManager
   }
 

--- a/session-loader/Development/IDE/Session.hs
+++ b/session-loader/Development/IDE/Session.hs
@@ -645,7 +645,7 @@ setOptions (ComponentOptions theOpts compRoot _) dflags = do
 setLinkerOptions :: DynFlags -> DynFlags
 setLinkerOptions df = df {
     ghcLink   = LinkInMemory
-  , hscTarget = HscAsm
+  , hscTarget = HscNothing
   , ghcMode = CompManager
   }
 

--- a/src/Development/IDE/Core/Compile.hs
+++ b/src/Development/IDE/Core/Compile.hs
@@ -175,7 +175,7 @@ mkTcModuleResultNoCompile session tcm = do
   (iface, _) <- mkIfaceTc session Nothing sf details tcGblEnv
 #endif
   let mod_info = HomeModInfo iface details Nothing
-  pure $ HiFileResult ms mod_info
+  pure $! HiFileResult ms mod_info
 
 mkTcModuleResultCompile
     :: HscEnv
@@ -207,7 +207,7 @@ mkTcModuleResultCompile session' tcm simplified_guts = catchErrs $ do
       (final_iface,_) <- mkIface session Nothing details simplified_guts
 #endif
       let mod_info = HomeModInfo final_iface details (Just linkable)
-      pure (diags, Just $ HiFileResult ms mod_info)
+      pure (diags, Just $! HiFileResult ms mod_info)
   where
     dflags = hsc_dflags session'
     source = "compile"

--- a/src/Development/IDE/Core/Compile.hs
+++ b/src/Development/IDE/Core/Compile.hs
@@ -221,9 +221,13 @@ generateObjectCode hscEnv tmr = do
                   fp = replaceExtension dot_o "s"
               liftIO $ createDirectoryIfMissing True (takeDirectory fp)
               (warnings, dot_o_fp) <-
-                withWarnings "object" $ \tweak -> liftIO $ do
+                withWarnings "object" $ \_tweak -> liftIO $ do
                       _ <- hscGenHardCode session guts
-                                (tweak summary)
+#if MIN_GHC_API_VERSION(8,10,0)
+                                (ms_location summary)
+#else
+                                (_tweak summary)
+#endif
                                 fp
                       compileFile session' StopLn (fp, Just (As False))
               let unlinked = DotO dot_o_fp

--- a/src/Development/IDE/Core/Compile.hs
+++ b/src/Development/IDE/Core/Compile.hs
@@ -16,8 +16,8 @@ module Development.IDE.Core.Compile
   , typecheckModule
   , computePackageDeps
   , addRelativeImport
-  , mkTcModuleResultCompile
-  , mkTcModuleResultNoCompile
+  , mkHiFileResultCompile
+  , mkHiFileResultNoCompile
   , generateObjectCode
   , generateByteCode
   , generateHieAsts
@@ -163,8 +163,8 @@ tcRnModule pmod = do
         Nothing -> error "no renamed info tcRnModule"
   pure (TcModuleResult pmod rn_info tc_gbl_env False)
 
-mkTcModuleResultNoCompile :: HscEnv -> TcModuleResult -> IO HiFileResult
-mkTcModuleResultNoCompile session tcm = do
+mkHiFileResultNoCompile :: HscEnv -> TcModuleResult -> IO HiFileResult
+mkHiFileResultNoCompile session tcm = do
   let hsc_env_tmp = session { hsc_dflags = ms_hspp_opts ms }
       ms = pm_mod_summary $ tmrParsed tcm
       tcGblEnv = tmrTypechecked tcm
@@ -178,12 +178,12 @@ mkTcModuleResultNoCompile session tcm = do
   let mod_info = HomeModInfo iface details Nothing
   pure $! HiFileResult ms mod_info
 
-mkTcModuleResultCompile
+mkHiFileResultCompile
     :: HscEnv
     -> TcModuleResult
     -> ModGuts
     -> IO (IdeResult HiFileResult)
-mkTcModuleResultCompile session' tcm simplified_guts = catchErrs $ do
+mkHiFileResultCompile session' tcm simplified_guts = catchErrs $ do
   let session = session' { hsc_dflags = ms_hspp_opts ms }
       ms = pm_mod_summary $ tmrParsed tcm
   -- give variables unique OccNames

--- a/src/Development/IDE/Core/Compile.hs
+++ b/src/Development/IDE/Core/Compile.hs
@@ -188,7 +188,7 @@ mkTcModuleResultCompile session' tcm simplified_guts = catchErrs $ do
   -- give variables unique OccNames
   (guts, details) <- tidyProgram session simplified_guts
 
-  (diags, obj_res) <- generateByteCode session ms guts
+  (diags, obj_res) <- generateObjectCode session ms guts
   case obj_res of
     Nothing -> do
 #if MIN_GHC_API_VERSION(8,10,0) 
@@ -741,7 +741,7 @@ loadInterface session ms sourceMod objNeeded regen = do
             -> do
              linkable <-
                if objNeeded
-               then pure Nothing -- liftIO $ findObjectLinkableMaybe (ms_mod ms) (ms_location ms)
+               then liftIO $ findObjectLinkableMaybe (ms_mod ms) (ms_location ms)
                else pure Nothing
              let objUpToDate = not objNeeded || case linkable of
                    Nothing -> False

--- a/src/Development/IDE/Core/Compile.hs
+++ b/src/Development/IDE/Core/Compile.hs
@@ -19,6 +19,7 @@ module Development.IDE.Core.Compile
   , mkTcModuleResultCompile
   , mkTcModuleResultNoCompile
   , generateObjectCode
+  , generateByteCode
   , generateHieAsts
   , writeHieFile
   , writeHiFile

--- a/src/Development/IDE/Core/Compile.hs
+++ b/src/Development/IDE/Core/Compile.hs
@@ -223,7 +223,7 @@ generateObjectCode hscEnv tmr = do
               (warnings, dot_o_fp) <-
                 withWarnings "object" $ \tweak -> liftIO $ do
                       _ <- hscGenHardCode session guts
-                                (tweak $ summary)
+                                (tweak summary)
                                 fp
                       compileFile session' StopLn (fp, Just (As False))
               let unlinked = DotO dot_o_fp

--- a/src/Development/IDE/Core/FileStore.hs
+++ b/src/Development/IDE/Core/FileStore.hs
@@ -236,7 +236,7 @@ typecheckParents state nfp = void $ shakeEnqueue (shakeExtras state) parents
 
 typecheckParentsAction :: NormalizedFilePath -> Action ()
 typecheckParentsAction nfp = do
-    revs <- reverseDependencies nfp <$> useNoFile_ GetModuleGraph
+    revs <- transitiveReverseDependencies nfp <$> useNoFile_ GetModuleGraph
     logger <- logger <$> getShakeExtras
     let log = L.logInfo logger . T.pack
     liftIO $ do

--- a/src/Development/IDE/Core/OfInterest.hs
+++ b/src/Development/IDE/Core/OfInterest.hs
@@ -94,10 +94,10 @@ kick = mkDelayedAction "kick" Debug $ do
     liftIO $ progressUpdate KickStarted
 
     -- Update the exports map for the project
-    results <- uses GenerateCore $ HashMap.keys files
+    results <- uses TypeCheck $ HashMap.keys files
     ShakeExtras{exportsMap} <- getShakeExtras
     let mguts = catMaybes results
-        !exportsMap' = createExportsMapMg mguts
+        !exportsMap' = createExportsMapTc $ map tmrTypechecked mguts
     liftIO $ modifyVar_ exportsMap $ evaluate . (exportsMap' <>)
 
     liftIO $ progressUpdate KickCompleted

--- a/src/Development/IDE/Core/OfInterest.hs
+++ b/src/Development/IDE/Core/OfInterest.hs
@@ -94,10 +94,10 @@ kick = mkDelayedAction "kick" Debug $ do
     liftIO $ progressUpdate KickStarted
 
     -- Update the exports map for the project
-    results <- uses TypeCheck $ HashMap.keys files
+    results <- uses GenerateCore $ HashMap.keys files
     ShakeExtras{exportsMap} <- getShakeExtras
     let mguts = catMaybes results
-        !exportsMap' = createExportsMapTc $ map tmrTypechecked mguts
+        !exportsMap' = createExportsMapMg mguts
     liftIO $ modifyVar_ exportsMap $ evaluate . (exportsMap' <>)
 
     liftIO $ progressUpdate KickCompleted

--- a/src/Development/IDE/Core/OfInterest.hs
+++ b/src/Development/IDE/Core/OfInterest.hs
@@ -101,9 +101,9 @@ kick = mkDelayedAction "kick" Debug $ do
         !exportsMap' = createExportsMap modIfaces
     liftIO $ modifyVar_ exportsMap $ evaluate . (exportsMap' <>)
 
-    -- Get desugarer warnings
-    _ <- uses GenerateCore $ HashMap.keys files
-    -- generate (and write) hie files for queries
-    _ <- uses GetHieAst $ HashMap.keys files
+    -- -- Get desugarer warnings
+    -- _ <- uses GenerateCore $ HashMap.keys files
+    -- -- generate (and write) hie files for queries
+    -- _ <- uses GetHieAst $ HashMap.keys files
 
     liftIO $ progressUpdate KickCompleted

--- a/src/Development/IDE/Core/OfInterest.hs
+++ b/src/Development/IDE/Core/OfInterest.hs
@@ -101,6 +101,9 @@ kick = mkDelayedAction "kick" Debug $ do
         !exportsMap' = createExportsMap modIfaces
     liftIO $ modifyVar_ exportsMap $ evaluate . (exportsMap' <>)
 
+    -- Get desugarer warnings
     _ <- uses GenerateCore $ HashMap.keys files
+    -- generate (and write) hie files for queries
+    _ <- uses GetHieAst $ HashMap.keys files
 
     liftIO $ progressUpdate KickCompleted

--- a/src/Development/IDE/Core/Rules.hs
+++ b/src/Development/IDE/Core/Rules.hs
@@ -822,9 +822,9 @@ getModIfaceRule = defineEarlyCutoff $ \GetModIface f -> do
 #else
     hsc <- hscEnv <$> use_ GhcSession f
     tm <- use TypeCheck f
-    !hiFile <- liftIO $ extractHiFileResult hsc False tm
+    (diags, !hiFile) <- liftIO $ extractHiFileResult hsc False tm
     let fp = hiFileFingerPrint <$> hiFile
-    return (fp, ([], tmr_hiFileResult <$> tm))
+    return (fp, (diags, hiFile))
 #endif
 
 regenerateHiFile :: HscEnvEq -> NormalizedFilePath -> Bool -> Action ([FileDiagnostic], Maybe HiFileResult)

--- a/src/Development/IDE/Core/Rules.hs
+++ b/src/Development/IDE/Core/Rules.hs
@@ -695,7 +695,7 @@ getModIfaceFromDiskRule = defineEarlyCutoff $ \GetModIfaceFromDisk f -> do
             (diags, Nothing) -> return (Nothing, (diags ++ diags_session, Nothing))
 
 isHiFileStableRule :: Rules ()
-isHiFileStableRule = define $ \IsHiFileStable f -> do
+isHiFileStableRule = defineEarlyCutoff $ \IsHiFileStable f -> do
     ms <- use_ GetModSummaryWithoutTimestamps f
     let hiFile = toNormalizedFilePath'
                 $ ml_hi_file $ ms_location ms
@@ -713,7 +713,7 @@ isHiFileStableRule = define $ \IsHiFileStable f -> do
                     pure $ if all (== SourceUnmodifiedAndStable) deps
                         then SourceUnmodifiedAndStable
                         else SourceUnmodified
-    return ([], Just sourceModified)
+    return (Just (BS.pack $ show sourceModified), ([], Just sourceModified))
 
 getModSummaryRule :: Rules ()
 getModSummaryRule = do

--- a/src/Development/IDE/Core/Rules.hs
+++ b/src/Development/IDE/Core/Rules.hs
@@ -857,11 +857,11 @@ regenerateHiFile sess f objNeeded = do
 
 extractHiFileResult :: HscEnv -> Bool -> Maybe TcModuleResult -> IO (IdeResult HiFileResult)
 extractHiFileResult _hsc _obj Nothing = pure ([],Nothing)
-extractHiFileResult _hsc False (Just tmr) = pure $ ([], Just $! HiFileResult (tmrModSummary tmr) (tmrModInfo tmr))
+extractHiFileResult _hsc False (Just tmr) = pure ([], Just $! HiFileResult (tmrModSummary tmr) (tmrModInfo tmr))
 extractHiFileResult hsc True (Just tmr) = do
   (diags, linkable) <- generateObjectCode hsc tmr
   let hmi = (tmrModInfo tmr) { hm_linkable = linkable }
-  pure $ (diags, Just $! HiFileResult (tmrModSummary tmr) hmi)
+  pure (diags, Just $! HiFileResult (tmrModSummary tmr) hmi)
 
 getClientSettingsRule :: Rules ()
 getClientSettingsRule = defineEarlyCutOffNoFile $ \GetClientSettings -> do

--- a/src/Development/IDE/Core/Rules.hs
+++ b/src/Development/IDE/Core/Rules.hs
@@ -876,8 +876,8 @@ needsObjectCodeRule = defineEarlyCutoff $ \NeedsObjectCode file -> do
   res <-
     if uses_th_qq ms
     then pure True
-    else anyM (use_ NeedsObjectCode) =<<
-           immediateReverseDependencies file <$> useNoFile_ GetModuleGraph
+    else anyM (use_ NeedsObjectCode) . immediateReverseDependencies file
+           =<< useNoFile_ GetModuleGraph
   pure (Just $ BS.pack $ show $ hash res, ([], Just res))
   where
     uses_th_qq (ms_hspp_opts -> dflags) =

--- a/src/Development/IDE/GHC/Orphans.hs
+++ b/src/Development/IDE/GHC/Orphans.hs
@@ -102,3 +102,8 @@ instance Show a => Show (Bag a) where
 
 instance NFData HsDocString where
     rnf = rwhnf
+
+instance Show ModGuts where
+    show _ = "modguts"
+instance NFData ModGuts where
+    rnf = rwhnf

--- a/src/Development/IDE/Import/DependencyInformation.hs
+++ b/src/Development/IDE/Import/DependencyInformation.hs
@@ -21,7 +21,8 @@ module Development.IDE.Import.DependencyInformation
   , reachableModules
   , processDependencyInformation
   , transitiveDeps
-  , reverseDependencies
+  , transitiveReverseDependencies
+  , immediateReverseDependencies
 
   , BootIdMap
   , insertBootId
@@ -316,8 +317,8 @@ partitionSCC (AcyclicSCC x:rest) = first (x:)   $ partitionSCC rest
 partitionSCC []                  = ([], [])
 
 -- | Transitive reverse dependencies of a file
-reverseDependencies :: NormalizedFilePath -> DependencyInformation -> [NormalizedFilePath]
-reverseDependencies file DependencyInformation{..} =
+transitiveReverseDependencies :: NormalizedFilePath -> DependencyInformation -> [NormalizedFilePath]
+transitiveReverseDependencies file DependencyInformation{..} =
   let FilePathId cur_id = pathToId depPathIdMap file
   in map (idToPath depPathIdMap . FilePathId) (IntSet.toList (go cur_id IntSet.empty))
   where
@@ -327,6 +328,12 @@ reverseDependencies file DependencyInformation{..} =
           res = IntSet.union i outwards
           new = IntSet.difference i outwards
       in IntSet.foldr go res new
+
+-- | Immediate reverse dependencies of a file
+immediateReverseDependencies :: NormalizedFilePath -> DependencyInformation -> [NormalizedFilePath]
+immediateReverseDependencies file DependencyInformation{..} =
+  let FilePathId cur_id = pathToId depPathIdMap file
+  in map (idToPath depPathIdMap . FilePathId) (maybe mempty IntSet.toList (IntMap.lookup cur_id depReverseModuleDeps))
 
 transitiveDeps :: DependencyInformation -> NormalizedFilePath -> Maybe TransitiveDependencies
 transitiveDeps DependencyInformation{..} file = do

--- a/src/Development/IDE/Import/DependencyInformation.hs
+++ b/src/Development/IDE/Import/DependencyInformation.hs
@@ -385,7 +385,7 @@ instance NFData TransitiveDependencies
 data NamedModuleDep = NamedModuleDep {
   nmdFilePath :: !NormalizedFilePath,
   nmdModuleName :: !ModuleName,
-  nmdModLocation :: !ModLocation
+  nmdModLocation :: !(Maybe ModLocation)
   }
   deriving Generic
 

--- a/src/Development/IDE/Import/FindImports.hs
+++ b/src/Development/IDE/Import/FindImports.hs
@@ -62,7 +62,7 @@ modSummaryToArtifactsLocation nfp ms = ArtifactsLocation nfp (ms_location <$> ms
     isSource HsSrcFile = True
     isSource _ = False
     source = case ms of
-      Nothing -> "-boot" `isSuffixOf` (fromNormalizedFilePath nfp)
+      Nothing -> "-boot" `isSuffixOf` fromNormalizedFilePath nfp
       Just ms -> isSource (ms_hsc_src ms)
 
 -- | locate a module in the file system. Where we go from *daml to Haskell

--- a/src/Development/IDE/Import/FindImports.hs
+++ b/src/Development/IDE/Import/FindImports.hs
@@ -32,6 +32,7 @@ import           Control.Monad.IO.Class
 import           System.FilePath
 import DriverPhases
 import Data.Maybe
+import Data.List (isSuffixOf)
 
 data Import
   = FileImport !ArtifactsLocation
@@ -40,7 +41,7 @@ data Import
 
 data ArtifactsLocation = ArtifactsLocation
   { artifactFilePath    :: !NormalizedFilePath
-  , artifactModLocation :: !ModLocation
+  , artifactModLocation :: !(Maybe ModLocation)
   , artifactIsSource    :: !Bool          -- ^ True if a module is a source input
   }
     deriving (Show)
@@ -55,12 +56,14 @@ instance NFData Import where
   rnf (FileImport x) = rnf x
   rnf (PackageImport x) = rnf x
 
-modSummaryToArtifactsLocation :: NormalizedFilePath -> ModSummary -> ArtifactsLocation
-modSummaryToArtifactsLocation nfp ms = ArtifactsLocation nfp (ms_location ms) (isSource (ms_hsc_src ms))
+modSummaryToArtifactsLocation :: NormalizedFilePath -> Maybe ModSummary -> ArtifactsLocation
+modSummaryToArtifactsLocation nfp ms = ArtifactsLocation nfp (ms_location <$> ms) source
   where
     isSource HsSrcFile = True
     isSource _ = False
-
+    source = case ms of
+      Nothing -> "-boot" `isSuffixOf` (fromNormalizedFilePath nfp)
+      Just ms -> isSource (ms_hsc_src ms)
 
 -- | locate a module in the file system. Where we go from *daml to Haskell
 locateModuleFile :: MonadIO m
@@ -123,7 +126,7 @@ locateModule dflags comp_info exts doesExist modName mbPkgName isSource = do
     import_paths = mapMaybe (mkImportDirs dflags) comp_info
     toModLocation file = liftIO $ do
         loc <- mkHomeModLocation dflags (unLoc modName) (fromNormalizedFilePath file)
-        return $ Right $ FileImport $ ArtifactsLocation file loc (not isSource)
+        return $ Right $ FileImport $ ArtifactsLocation file (Just loc) (not isSource)
 
     lookupLocal dirs = do
       mbFile <- locateModuleFile dirs exts doesExist isSource $ unLoc modName

--- a/src/Development/IDE/Plugin/Completions.hs
+++ b/src/Development/IDE/Plugin/Completions.hs
@@ -92,8 +92,8 @@ produceCompletions = do
                                     }
                         tm <- liftIO $ typecheckModule (IdeDefer True) env pm
                         case tm of
-                            (_, Just (_,TcModuleResult{..})) -> do
-                                cdata <- liftIO $ cacheDataProducer env tmrModule parsedDeps
+                            (_, Just (_,tcm)) -> do
+                                cdata <- liftIO $ cacheDataProducer env tcm parsedDeps
                                 -- Do not return diags from parsing as they would duplicate
                                 -- the diagnostics from typechecking
                                 return ([], Just cdata)

--- a/src/Development/IDE/Spans/AtPoint.hs
+++ b/src/Development/IDE/Spans/AtPoint.hs
@@ -30,6 +30,7 @@ import SrcLoc
 import TyCoRep
 import TyCon
 import qualified Var
+import NameEnv
 
 import Control.Applicative
 import Control.Monad.Extra
@@ -114,11 +115,13 @@ atPoint IdeOptions{} hf (DKMap dm km) pos = listToMaybe $ pointCommand hf pos ho
         prettyNames :: [T.Text]
         prettyNames = map prettyName names
         prettyName (Right n, dets) = T.unlines $
-          wrapHaskell (showName n <> maybe "" ((" :: " <>) . prettyType) (identType dets <|> M.lookup n km))
+          wrapHaskell (showName n <> maybe "" ((" :: " <>) . prettyType) (identType dets <|> maybeKind))
           : definedAt n
-          : catMaybes [ T.unlines . spanDocToMarkdown <$> M.lookup n dm
+          : catMaybes [ T.unlines . spanDocToMarkdown <$> lookupNameEnv dm n
                       ]
+          where maybeKind = safeTyThingType =<< lookupNameEnv km n
         prettyName (Left m,_) = showName m
+
 
         prettyTypes = map (("_ :: "<>) . prettyType) types
         prettyType t = showName t

--- a/src/Development/IDE/Spans/Common.hs
+++ b/src/Development/IDE/Spans/Common.hs
@@ -20,7 +20,6 @@ module Development.IDE.Spans.Common (
 import Data.Maybe
 import qualified Data.Text as T
 import Data.List.Extra
-import Data.Map (Map)
 import Control.DeepSeq
 import GHC.Generics
 
@@ -30,13 +29,14 @@ import DynFlags
 import ConLike
 import DataCon
 import Var
+import NameEnv
 
 import qualified Documentation.Haddock.Parser as H
 import qualified Documentation.Haddock.Types as H
 import Development.IDE.GHC.Orphans ()
 
-type DocMap = Map Name SpanDoc
-type KindMap = Map Name Type
+type DocMap = NameEnv SpanDoc
+type KindMap = NameEnv TyThing
 
 showGhc :: Outputable a => a -> String
 showGhc = showPpr unsafeGlobalDynFlags

--- a/src/Development/IDE/Spans/Documentation.hs
+++ b/src/Development/IDE/Spans/Documentation.hs
@@ -38,7 +38,7 @@ import           Name
 import           Language.Haskell.LSP.Types (getUri, filePathToUri)
 import           TcRnTypes
 import           ExtractDocs
-import NameEnv
+import           NameEnv
 
 mkDocMap
   :: GhcMonad m
@@ -52,7 +52,9 @@ mkDocMap sources rm this_mod =
      k <- foldrM getType (tcg_type_env this_mod) names
      pure $ DKMap d k
   where
-    getDocs n map = do
+    getDocs n map
+      | maybe True (mod ==) $ nameModule_maybe n = pure map -- we already have the docs in this_docs, or they do not exist
+      | otherwise = do
       doc <- getDocumentationTryGhc mod sources n
       pure $ extendNameEnv map n doc
     getType n map

--- a/src/Development/IDE/Spans/Documentation.hs
+++ b/src/Development/IDE/Spans/Documentation.hs
@@ -60,7 +60,7 @@ mkDocMap sources rm hmi =
       | otherwise = pure map
     names = rights $ S.toList idents
     idents = M.keysSet rm
-    mod = mi_module $ hm_iface $ hmi
+    mod = mi_module $ hm_iface hmi
 
 lookupKind :: GhcMonad m => Module -> Name -> m (Maybe Type)
 lookupKind mod =

--- a/src/Development/IDE/Types/Exports.hs
+++ b/src/Development/IDE/Types/Exports.hs
@@ -5,7 +5,8 @@ module Development.IDE.Types.Exports
     IdentInfo(..),
     ExportsMap(..),
     createExportsMap,
-    createExportsMapMg
+    createExportsMapMg,
+    createExportsMapTc
 ) where
 
 import Avail (AvailInfo(..))
@@ -23,6 +24,7 @@ import Data.HashSet (HashSet)
 import qualified Data.HashSet as Set
 import Data.Bifunctor (Bifunctor(second))
 import Data.Hashable (Hashable)
+import TcRnTypes(TcGblEnv(..))
 
 newtype ExportsMap = ExportsMap
     {getExportsMap :: HashMap IdentifierText (HashSet (IdentInfo,ModuleNameText))}
@@ -76,6 +78,13 @@ createExportsMapMg = ExportsMap . Map.fromListWith (<>) . concatMap doOne
     doOne mi = concatMap (fmap (second Set.fromList) . unpackAvail mn) (mg_exports mi)
       where
         mn = moduleName $ mg_module mi
+
+createExportsMapTc :: [TcGblEnv] -> ExportsMap
+createExportsMapTc = ExportsMap . Map.fromListWith (<>) . concatMap doOne
+  where
+    doOne mi = concatMap (fmap (second Set.fromList) . unpackAvail mn) (tcg_exports mi)
+      where
+        mn = moduleName $ tcg_mod mi
 
 unpackAvail :: ModuleName -> IfaceExport -> [(Text, [(IdentInfo, Text)])]
 unpackAvail mod =

--- a/src/Development/IDE/Types/Exports.hs
+++ b/src/Development/IDE/Types/Exports.hs
@@ -5,6 +5,7 @@ module Development.IDE.Types.Exports
     IdentInfo(..),
     ExportsMap(..),
     createExportsMap,
+    createExportsMapMg
 ) where
 
 import Avail (AvailInfo(..))
@@ -17,7 +18,7 @@ import GHC.Generics (Generic)
 import Name
 import FieldLabel (flSelector)
 import qualified Data.HashMap.Strict as Map
-import GhcPlugins (IfaceExport)
+import GhcPlugins (IfaceExport, ModGuts(..))
 import Data.HashSet (HashSet)
 import qualified Data.HashSet as Set
 import Data.Bifunctor (Bifunctor(second))
@@ -68,6 +69,13 @@ createExportsMap = ExportsMap . Map.fromListWith (<>) . concatMap doOne
     doOne mi = concatMap (fmap (second Set.fromList) . unpackAvail mn) (mi_exports mi)
       where
         mn = moduleName $ mi_module mi
+
+createExportsMapMg :: [ModGuts] -> ExportsMap
+createExportsMapMg = ExportsMap . Map.fromListWith (<>) . concatMap doOne
+  where
+    doOne mi = concatMap (fmap (second Set.fromList) . unpackAvail mn) (mg_exports mi)
+      where
+        mn = moduleName $ mg_module mi
 
 unpackAvail :: ModuleName -> IfaceExport -> [(Text, [(IdentInfo, Text)])]
 unpackAvail mod =

--- a/test/exe/Main.hs
+++ b/test/exe/Main.hs
@@ -2461,7 +2461,7 @@ thTests =
         _ <- createDoc "A.hs" "haskell" sourceA
         _ <- createDoc "B.hs" "haskell" sourceB
         expectDiagnostics [ ( "B.hs", [(DsWarning, (4, 0), "Top-level binding with no type signature: main :: IO ()")] ) ]
-    , flip xfail "expect broken (#614)" $ testCase "findsTHnewNameConstructor" $ withoutStackEnv $ runWithExtraFiles "THNewName" $ \dir -> do
+    , testCase "findsTHnewNameConstructor" $ withoutStackEnv $ runWithExtraFiles "THNewName" $ \dir -> do
 
     -- This test defines a TH value with the meaning "data A = A" in A.hs
     -- Loads and export the template in B.hs

--- a/test/exe/Main.hs
+++ b/test/exe/Main.hs
@@ -3247,8 +3247,6 @@ ifaceErrorTest = testCase "iface-error-test-1" $ withoutStackEnv $ runWithExtraF
       ResponseMessage{_result=Right hidir} -> do
         hi_exists <- doesFileExist $ hidir </> "B.hi"
         assertBool ("Couldn't find B.hi in " ++ hidir) hi_exists
-        hie_exists <- doesFileExist $ hidir </> "B.hie"
-        assertBool ("Couldn't find B.hie in " ++ hidir) hie_exists
       _ -> assertFailure $ "Got malformed response for CustomMessage hidir: " ++ show res
 
     pdoc <- createDoc pPath "haskell" pSource

--- a/test/exe/Main.hs
+++ b/test/exe/Main.hs
@@ -284,7 +284,7 @@ diagnosticTests = testGroup "diagnostics"
       let contentA = T.unlines [ "module ModuleA where" ]
       _ <- createDoc "ModuleA.hs" "haskell" contentA
       expectDiagnostics [("ModuleB.hs", [])]
-  , testSessionWait "add missing module (non workspace)" $ do
+  , ignoreInWindowsBecause "Broken in windows" $ testSessionWait "add missing module (non workspace)" $ do
       tmpDir <- liftIO getTemporaryDirectory
       let contentB = T.unlines
             [ "module ModuleB where"


### PR DESCRIPTION
Rework of https://github.com/mpickering/ghcide/pull/43/

Should improve performance and also functions as a workaround for #614 

We now generate object code along with the interface file. Object code is only generated for a module if

1) The module uses TH
2) Any parents of the module use TH

For this to work, we require the complete module graph. Earlier, tests were failing because `TargetFile`'s were not included in the set of known files. I fixed this, but now tests are failing because the modules don't define a `main` function. Any idea why this is happening @pepeiborra? See my last commit.

FIxes #614 
Fixes #107 