### PR TITLE
Fix code action for adding missing constraints to type signatures

### DIFF
--- a/test/exe/Main.hs
+++ b/test/exe/Main.hs
@@ -1667,20 +1667,18 @@ addInstanceConstraintTests = let
 
 addFunctionConstraintTests :: TestTree
 addFunctionConstraintTests = let
-  missingConstraintSourceCode :: Maybe T.Text -> T.Text
-  missingConstraintSourceCode mConstraint =
-    let constraint = maybe "" (<> " => ") mConstraint
-     in T.unlines
+  missingConstraintSourceCode :: T.Text -> T.Text
+  missingConstraintSourceCode constraint =
+    T.unlines
     [ "module Testing where"
     , ""
     , "eq :: " <> constraint <> "a -> a -> Bool"
     , "eq x y = x == y"
     ]
 
-  incompleteConstraintSourceCode :: Maybe T.Text -> T.Text
-  incompleteConstraintSourceCode mConstraint =
-    let constraint = maybe "Eq a" (\c -> "(Eq a, " <> c <> ")") mConstraint
-     in T.unlines
+  incompleteConstraintSourceCode :: T.Text -> T.Text
+  incompleteConstraintSourceCode constraint =
+    T.unlines
     [ "module Testing where"
     , ""
     , "data Pair a b = Pair a b"
@@ -1689,10 +1687,9 @@ addFunctionConstraintTests = let
     , "eq (Pair x y) (Pair x' y') = x == x' && y == y'"
     ]
 
-  incompleteConstraintSourceCode2 :: Maybe T.Text -> T.Text
-  incompleteConstraintSourceCode2 mConstraint =
-    let constraint = maybe "(Eq a, Eq b)" (\c -> "(Eq a, Eq b, " <> c <> ")") mConstraint
-     in T.unlines
+  incompleteConstraintSourceCode2 :: T.Text -> T.Text
+  incompleteConstraintSourceCode2 constraint =
+    T.unlines
     [ "module Testing where"
     , ""
     , "data Three a b c = Three a b c"
@@ -1701,10 +1698,9 @@ addFunctionConstraintTests = let
     , "eq (Three x y z) (Three x' y' z') = x == x' && y == y' && z == z'"
     ]
 
-  incompleteConstraintSourceCodeWithExtraCharsInContext :: Maybe T.Text -> T.Text
-  incompleteConstraintSourceCodeWithExtraCharsInContext mConstraint =
-    let constraint = maybe "( Eq a )" (\c -> "(Eq a, " <> c <> ")") mConstraint
-     in T.unlines
+  incompleteConstraintSourceCodeWithExtraCharsInContext :: T.Text -> T.Text
+  incompleteConstraintSourceCodeWithExtraCharsInContext constraint =
+    T.unlines
     [ "module Testing where"
     , ""
     , "data Pair a b = Pair a b"
@@ -1713,10 +1709,9 @@ addFunctionConstraintTests = let
     , "eq (Pair x y) (Pair x' y') = x == x' && y == y'"
     ]
   
-  incompleteConstraintSourceCodeWithNewlinesInTypeSignature :: Maybe T.Text -> T.Text
-  incompleteConstraintSourceCodeWithNewlinesInTypeSignature mConstraint =
-    let constraint = maybe "(Eq a)" (\c -> "(Eq a, " <> c <> ")") mConstraint
-     in T.unlines
+  incompleteConstraintSourceCodeWithNewlinesInTypeSignature :: T.Text -> T.Text
+  incompleteConstraintSourceCodeWithNewlinesInTypeSignature constraint =
+    T.unlines
     [ "module Testing where"
     , "data Pair a b = Pair a b"
     , "eq "
@@ -1738,24 +1733,24 @@ addFunctionConstraintTests = let
   in testGroup "add function constraint"
   [ check
     "Add `Eq a` to the context of the type signature for `eq`"
-    (missingConstraintSourceCode Nothing)
-    (missingConstraintSourceCode $ Just "Eq a")
+    (missingConstraintSourceCode "")
+    (missingConstraintSourceCode "Eq a => ")
   , check
     "Add `Eq b` to the context of the type signature for `eq`"
-    (incompleteConstraintSourceCode Nothing)
-    (incompleteConstraintSourceCode $ Just "Eq b")
+    (incompleteConstraintSourceCode "Eq a")
+    (incompleteConstraintSourceCode "(Eq a, Eq b)")
   , check
     "Add `Eq c` to the context of the type signature for `eq`"
-    (incompleteConstraintSourceCode2 Nothing)
-    (incompleteConstraintSourceCode2 $ Just "Eq c")
+    (incompleteConstraintSourceCode2 "(Eq a, Eq b)")
+    (incompleteConstraintSourceCode2 "(Eq a, Eq b, Eq c)")
   , check
     "Add `Eq b` to the context of the type signature for `eq`"
-    (incompleteConstraintSourceCodeWithExtraCharsInContext Nothing)
-    (incompleteConstraintSourceCodeWithExtraCharsInContext $ Just "Eq b")
+    (incompleteConstraintSourceCodeWithExtraCharsInContext "( Eq a )")
+    (incompleteConstraintSourceCodeWithExtraCharsInContext "(Eq a, Eq b)")
   , check
     "Add `Eq b` to the context of the type signature for `eq`"
-    (incompleteConstraintSourceCodeWithNewlinesInTypeSignature Nothing)
-    (incompleteConstraintSourceCodeWithNewlinesInTypeSignature $ Just "Eq b")
+    (incompleteConstraintSourceCodeWithNewlinesInTypeSignature "(Eq a)")
+    (incompleteConstraintSourceCodeWithNewlinesInTypeSignature "(Eq a, Eq b)")
   ]
 
 removeRedundantConstraintsTests :: TestTree

--- a/test/exe/Main.hs
+++ b/test/exe/Main.hs
@@ -1701,6 +1701,30 @@ addFunctionConstraintTests = let
     , "eq (Three x y z) (Three x' y' z') = x == x' && y == y' && z == z'"
     ]
 
+  incompleteConstraintSourceCodeWithExtraCharsInContext :: Maybe T.Text -> T.Text
+  incompleteConstraintSourceCodeWithExtraCharsInContext mConstraint =
+    let constraint = maybe "( Eq a )" (\c -> "(Eq a, " <> c <> ")") mConstraint
+     in T.unlines
+    [ "module Testing where"
+    , ""
+    , "data Pair a b = Pair a b"
+    , ""
+    , "eq :: " <> constraint <> " => Pair a b -> Pair a b -> Bool"
+    , "eq (Pair x y) (Pair x' y') = x == x' && y == y'"
+    ]
+  
+  incompleteConstraintSourceCodeWithNewlinesInTypeSignature :: Maybe T.Text -> T.Text
+  incompleteConstraintSourceCodeWithNewlinesInTypeSignature mConstraint =
+    let constraint = maybe "(Eq a)" (\c -> "(Eq a, " <> c <> ")") mConstraint
+     in T.unlines
+    [ "module Testing where"
+    , "data Pair a b = Pair a b"
+    , "eq "
+    , "    :: " <> constraint
+    , "    => Pair a b -> Pair a b -> Bool"
+    , "eq (Pair x y) (Pair x' y') = x == x' && y == y'"
+    ]
+
   check :: T.Text -> T.Text -> T.Text -> TestTree
   check actionTitle originalCode expectedCode = testSession (T.unpack actionTitle) $ do
     doc <- createDoc "Testing.hs" "haskell" originalCode
@@ -1724,6 +1748,14 @@ addFunctionConstraintTests = let
     "Add `Eq c` to the context of the type signature for `eq`"
     (incompleteConstraintSourceCode2 Nothing)
     (incompleteConstraintSourceCode2 $ Just "Eq c")
+  , check
+    "Add `Eq b` to the context of the type signature for `eq`"
+    (incompleteConstraintSourceCodeWithExtraCharsInContext Nothing)
+    (incompleteConstraintSourceCodeWithExtraCharsInContext $ Just "Eq b")
+  , check
+    "Add `Eq b` to the context of the type signature for `eq`"
+    (incompleteConstraintSourceCodeWithNewlinesInTypeSignature Nothing)
+    (incompleteConstraintSourceCodeWithNewlinesInTypeSignature $ Just "Eq b")
   ]
 
 removeRedundantConstraintsTests :: TestTree


### PR DESCRIPTION
I'm trying to fix [this issue](https://github.com/haskell/haskell-language-server/issues/360), which is quite relevant for our codebase at work: we have many type signatures like this, for which the code action `"Add CONSTRAINT to the context of the type signature for FUNCTION"` doesn't work.

```haskell
someFunction
    :: ( WithDb env m
       , WithError m
       , Has PieceOfConfig env
       )
    => Id User
    -> Id ProjectInfo
    -> m ProjectInfo
someFunction userId projectId = do
...
```

I added 2 failing tests illustrating both issues. The current implementation seems quite brittle (based on parsing stuff with regexes), I'm trying to figure out how to make it more robust..