### PR TITLE
Rerun Windows tests just like linux tests

### DIFF
--- a/.azure/windows-stack.yml
+++ b/.azure/windows-stack.yml
@@ -55,8 +55,8 @@ jobs:
     displayName: 'stack build --only-dependencies'
   - bash: |
       if [ "$STACK_YAML" = "stack8101.yaml" ]; then
-        stack test --ghc-options="-Werror -fexternal-interpreter" --stack-yaml $STACK_YAML
+        stack test --ghc-options="-Werror -fexternal-interpreter" --stack-yaml $STACK_YAML || stack test --ghc-options="-Werror -fexternal-interpreter" --stack-yaml=$STACK_YAML --ta "--rerun" || LSP_TEST_LOG_COLOR=0 LSP_TEST_LOG_MESSAGES=true LSP_TEST_LOG_STDERR=true stack test --ghc-options="-Werror -fexternal-interpreter" --stack-yaml=$STACK_YAML --ta "--rerun"
       else
-        stack test --ghc-options=-Werror --stack-yaml $STACK_YAML
+        stack test --ghc-options=-Werror --stack-yaml $STACK_YAML || stack test --ghc-options=-Werror --stack-yaml=$STACK_YAML --ta "--rerun" || LSP_TEST_LOG_COLOR=0 LSP_TEST_LOG_MESSAGES=true LSP_TEST_LOG_STDERR=true stack test --ghc-options=-Werror --stack-yaml=$STACK_YAML --ta "--rerun"
       fi
     displayName: 'stack test --ghc-options=-Werror'


### PR DESCRIPTION
1. Rerun only the failing tests
2. Rerun only the failing tests and produce an LSP log for diagnosis