### PR TITLE
Downgrade file watch debug log to logDebug from logInfo

### DIFF
--- a/src/Development/IDE/LSP/Notifications.hs
+++ b/src/Development/IDE/LSP/Notifications.hs
@@ -85,7 +85,7 @@ setHandlersNotifications = PartialHandlers $ \WithMessage{..} x -> return x
                         )
                         ( F.toList fileEvents )
             let msg = Text.pack $ show events
-            logInfo (ideLogger ide) $ "Files created or deleted: " <> msg
+            logDebug (ideLogger ide) $ "Files created or deleted: " <> msg
             modifyFileExists ide events
             setSomethingModified ide
 


### PR DESCRIPTION
This gets quite noisy when cabal is building dependencies which makes it
hard to see what's going on.