### PR TITLE
Format imports with stylish-haskell-0.12.1.0

### DIFF
--- a/.stylish-haskell.yaml
+++ b/.stylish-haskell.yaml
@@ -1,0 +1,345 @@
+# stylish-haskell configuration file
+# ==================================
+
+# The stylish-haskell tool is mainly configured by specifying steps. These steps
+# are a list, so they have an order, and one specific step may appear more than
+# once (if needed). Each file is processed by these steps in the given order.
+steps:
+  # Convert some ASCII sequences to their Unicode equivalents. This is disabled
+  # by default.
+  # - unicode_syntax:
+  #     # In order to make this work, we also need to insert the UnicodeSyntax
+  #     # language pragma. If this flag is set to true, we insert it when it's
+  #     # not already present. You may want to disable it if you configure
+  #     # language extensions using some other method than pragmas. Default:
+  #     # true.
+  #     add_language_pragma: true
+
+  # Format module header
+  #
+  # Currently, this option is not configurable and will format all exports and
+  # module declarations to minimize diffs
+  #
+  - module_header:
+  #     # How many spaces use for indentation in the module header.
+      indent: 4
+  #
+  #     # Should export lists be sorted?  Sorting is only performed within the
+  #     # export section, as delineated by Haddock comments.
+      sort: true
+
+  # Format record definitions. This is disabled by default.
+  #
+  # You can control the layout of record fields. The only rules that can't be configured
+  # are these:
+  #
+  # - "|" is always aligned with "="
+  # - "," in fields is always aligned with "{"
+  # - "}" is likewise always aligned with "{"
+  #
+  # - records:
+  #     # How to format equals sign between type constructor and data constructor.
+  #     # Possible values:
+  #     # - "same_line" -- leave "=" AND data constructor on the same line as the type constructor.
+  #     # - "indent N" -- insert a new line and N spaces from the beginning of the next line.
+  #     equals: "indent 2"
+  #
+  #     # How to format first field of each record constructor.
+  #     # Possible values:
+  #     # - "same_line" -- "{" and first field goes on the same line as the data constructor.
+  #     # - "indent N" -- insert a new line and N spaces from the beginning of the data constructor
+  #     first_field: "indent 2"
+  #
+  #     # How many spaces to insert between the column with "," and the beginning of the comment in the next line.
+  #     field_comment: 2
+  #
+  #     # How many spaces to insert before "deriving" clause. Deriving clauses are always on separate lines.
+  #     deriving: 2
+  #
+  #     # How many spaces to insert before "via" clause counted from indentation of deriving clause
+  #     # Possible values:
+  #     # - "same_line" -- "{" and first field goes on the same line as the data constructor.
+  #     # - "indent N" -- insert a new line and N spaces from the beginning of the data constructor
+  #     via: "indent 2"
+  #
+  #     # Wheter or not to break enums onto several lines
+  #     #
+  #     # Default: false
+  #     break_enums: false
+  #
+  #     # Whether or not to break single constructor data types before `=` sign
+  #     #
+  #     # Default: true
+  #     break_single_constructors: true
+  #
+  #     # Whether or not to curry constraints on function.
+  #     #
+  #     # E.g: @allValues :: Enum a => Bounded a => Proxy a -> [a]@
+  #     #
+  #     # Instead of @allValues :: (Enum a, Bounded a) => Proxy a -> [a]@
+  #     #
+  #     # Default: false
+  #     curried_context: false
+
+  # Align the right hand side of some elements.  This is quite conservative
+  # and only applies to statements where each element occupies a single
+  # line. All default to true.
+  - simple_align:
+      cases: false
+      top_level_patterns: false
+      records: false
+
+  # Import cleanup
+  - imports:
+      # There are different ways we can align names and lists.
+      #
+      # - global: Align the import names and import list throughout the entire
+      #   file.
+      #
+      # - file: Like global, but don't add padding when there are no qualified
+      #   imports in the file.
+      #
+      # - group: Only align the imports per group (a group is formed by adjacent
+      #   import lines).
+      #
+      # - none: Do not perform any alignment.
+      #
+      # Default: global.
+      align: global
+
+      # The following options affect only import list alignment.
+      #
+      # List align has following options:
+      #
+      # - after_alias: Import list is aligned with end of import including
+      #   'as' and 'hiding' keywords.
+      #
+      #   > import qualified Data.List      as List (concat, foldl, foldr, head,
+      #   >                                          init, last, length)
+      #
+      # - with_alias: Import list is aligned with start of alias or hiding.
+      #
+      #   > import qualified Data.List      as List (concat, foldl, foldr, head,
+      #   >                                 init, last, length)
+      #
+      # - with_module_name: Import list is aligned `list_padding` spaces after
+      #   the module name.
+      #
+      #   > import qualified Data.List      as List (concat, foldl, foldr, head,
+      #                          init, last, length)
+      #
+      #   This is mainly intended for use with `pad_module_names: false`.
+      #
+      #   > import qualified Data.List as List (concat, foldl, foldr, head,
+      #                          init, last, length, scanl, scanr, take, drop,
+      #                          sort, nub)
+      #
+      # - new_line: Import list starts always on new line.
+      #
+      #   > import qualified Data.List      as List
+      #   >     (concat, foldl, foldr, head, init, last, length)
+      #
+      # - repeat: Repeat the module name to align the import list.
+      #
+      #   > import qualified Data.List      as List (concat, foldl, foldr, head)
+      #   > import qualified Data.List      as List (init, last, length)
+      #
+      # Default: after_alias
+      list_align: after_alias
+
+      # Right-pad the module names to align imports in a group:
+      #
+      # - true: a little more readable
+      #
+      #   > import qualified Data.List       as List (concat, foldl, foldr,
+      #   >                                           init, last, length)
+      #   > import qualified Data.List.Extra as List (concat, foldl, foldr,
+      #   >                                           init, last, length)
+      #
+      # - false: diff-safe
+      #
+      #   > import qualified Data.List as List (concat, foldl, foldr, init,
+      #   >                                     last, length)
+      #   > import qualified Data.List.Extra as List (concat, foldl, foldr,
+      #   >                                           init, last, length)
+      #
+      # Default: true
+      pad_module_names: true
+
+      # Long list align style takes effect when import is too long. This is
+      # determined by 'columns' setting.
+      #
+      # - inline: This option will put as much specs on same line as possible.
+      #
+      # - new_line: Import list will start on new line.
+      #
+      # - new_line_multiline: Import list will start on new line when it's
+      #   short enough to fit to single line. Otherwise it'll be multiline.
+      #
+      # - multiline: One line per import list entry.
+      #   Type with constructor list acts like single import.
+      #
+      #   > import qualified Data.Map as M
+      #   >     ( empty
+      #   >     , singleton
+      #   >     , ...
+      #   >     , delete
+      #   >     )
+      #
+      # Default: inline
+      long_list_align: inline
+
+      # Align empty list (importing instances)
+      #
+      # Empty list align has following options
+      #
+      # - inherit: inherit list_align setting
+      #
+      # - right_after: () is right after the module name:
+      #
+      #   > import Vector.Instances ()
+      #
+      # Default: inherit
+      empty_list_align: inherit
+
+      # List padding determines indentation of import list on lines after import.
+      # This option affects 'long_list_align'.
+      #
+      # - <integer>: constant value
+      #
+      # - module_name: align under start of module name.
+      #   Useful for 'file' and 'group' align settings.
+      #
+      # Default: 4
+      list_padding: 4
+
+      # Separate lists option affects formatting of import list for type
+      # or class. The only difference is single space between type and list
+      # of constructors, selectors and class functions.
+      #
+      # - true: There is single space between Foldable type and list of it's
+      #   functions.
+      #
+      #   > import Data.Foldable (Foldable (fold, foldl, foldMap))
+      #
+      # - false: There is no space between Foldable type and list of it's
+      #   functions.
+      #
+      #   > import Data.Foldable (Foldable(fold, foldl, foldMap))
+      #
+      # Default: true
+      separate_lists: true
+
+      # Space surround option affects formatting of import lists on a single
+      # line. The only difference is single space after the initial
+      # parenthesis and a single space before the terminal parenthesis.
+      #
+      # - true: There is single space associated with the enclosing
+      #   parenthesis.
+      #
+      #   > import Data.Foo ( foo )
+      #
+      # - false: There is no space associated with the enclosing parenthesis
+      #
+      #   > import Data.Foo (foo)
+      #
+      # Default: false
+      space_surround: false
+
+      # Enabling this argument will use the new GHC lib parse to format imports.
+      #
+      # This currently assumes a few things, it will assume that you want post
+      # qualified imports. It is also not as feature complete as the old
+      # imports formatting.
+      #
+      # It does not remove redundant lines or merge lines. As such, the full
+      # feature scope is still pending.
+      #
+      # It _is_ however, a fine alternative if you are using features that are
+      # not parseable by haskell src extensions and you're comfortable with the
+      # presets.
+      #
+      # Default: false
+      ghc_lib_parser: true
+
+  # Language pragmas
+  - language_pragmas:
+      # We can generate different styles of language pragma lists.
+      #
+      # - vertical: Vertical-spaced language pragmas, one per line.
+      #
+      # - compact: A more compact style.
+      #
+      # - compact_line: Similar to compact, but wrap each line with
+      #   `{-#LANGUAGE #-}'.
+      #
+      # Default: vertical.
+      style: vertical
+
+      # Align affects alignment of closing pragma brackets.
+      #
+      # - true: Brackets are aligned in same column.
+      #
+      # - false: Brackets are not aligned together. There is only one space
+      #   between actual import and closing bracket.
+      #
+      # Default: true
+      align: true
+
+      # stylish-haskell can detect redundancy of some language pragmas. If this
+      # is set to true, it will remove those redundant pragmas. Default: true.
+      remove_redundant: true
+
+      # Language prefix to be used for pragma declaration, this allows you to
+      # use other options non case-sensitive like "language" or "Language".
+      # If a non correct String is provided, it will default to: LANGUAGE.
+      language_prefix: LANGUAGE
+
+  # Replace tabs by spaces. This is disabled by default.
+  # - tabs:
+  #     # Number of spaces to use for each tab. Default: 8, as specified by the
+  #     # Haskell report.
+  #     spaces: 8
+
+  # Remove trailing whitespace
+  - trailing_whitespace: {}
+
+  # Squash multiple spaces between the left and right hand sides of some
+  # elements into single spaces. Basically, this undoes the effect of
+  # simple_align but is a bit less conservative.
+  # - squash: {}
+
+# A common setting is the number of columns (parts of) code will be wrapped
+# to. Different steps take this into account.
+#
+# Set this to null to disable all line wrapping.
+#
+# Default: 80.
+columns: 120
+
+# By default, line endings are converted according to the OS. You can override
+# preferred format here.
+#
+# - native: Native newline format. CRLF on Windows, LF on other OSes.
+#
+# - lf: Convert to LF ("\n").
+#
+# - crlf: Convert to CRLF ("\r\n").
+#
+# Default: native.
+newline: native
+
+# Sometimes, language extensions are specified in a cabal file or from the
+# command line instead of using language pragmas in the file. stylish-haskell
+# needs to be aware of these, so it can parse the file correctly.
+#
+# No language extensions are enabled by default.
+# language_extensions:
+  # - TemplateHaskell
+  # - QuasiQuotes
+
+# Attempt to find the cabal file in ancestors of the current directory, and
+# parse options (currently only language extensions) from that.
+#
+# Default: true
+cabal: true

--- a/bench/hist/Main.hs
+++ b/bench/hist/Main.hs
@@ -39,27 +39,28 @@
 {-# LANGUAGE DerivingStrategies#-}
 {-# LANGUAGE TypeFamilies      #-}
 
-import Control.Applicative (Alternative (empty))
-import Control.Monad (when, forM, forM_, replicateM)
-import Data.Char (toLower)
-import Data.Foldable (find)
-import Data.Maybe (fromMaybe)
-import Data.Text (Text)
-import qualified Data.Text as T
-import Data.Yaml ((.!=), (.:?), FromJSON (..), ToJSON (..), Value (..), decodeFileThrow)
-import Development.Shake
-import Development.Shake.Classes (Binary, Hashable, NFData)
-import Experiments.Types (exampleToOptions, Example(..))
-import GHC.Exts (IsList (..))
-import GHC.Generics (Generic)
+import           Control.Applicative                       (Alternative (empty))
+import           Control.Monad                             (forM, forM_, replicateM, when)
+import           Data.Char                                 (toLower)
+import           Data.Foldable                             (find)
+import           Data.Maybe                                (fromMaybe)
+import           Data.Text                                 (Text)
+import qualified Data.Text                                 as T
+import           Data.Yaml                                 (FromJSON (..), ToJSON (..), Value (..), decodeFileThrow,
+                                                            (.!=), (.:?))
+import           Development.Shake
+import           Development.Shake.Classes                 (Binary, Hashable, NFData)
+import           Experiments.Types                         (Example (..), exampleToOptions)
+import           GHC.Exts                                  (IsList (..))
+import           GHC.Generics                              (Generic)
 import qualified Graphics.Rendering.Chart.Backend.Diagrams as E
-import Graphics.Rendering.Chart.Easy ((.=))
-import qualified Graphics.Rendering.Chart.Easy as E
-import Numeric.Natural (Natural)
-import System.Directory
-import System.FilePath
-import qualified Text.ParserCombinators.ReadP as P
-import Text.Read (Read (..), get, readMaybe, readP_to_Prec)
+import           Graphics.Rendering.Chart.Easy             ((.=))
+import qualified Graphics.Rendering.Chart.Easy             as E
+import           Numeric.Natural                           (Natural)
+import           System.Directory
+import           System.FilePath
+import qualified Text.ParserCombinators.ReadP              as P
+import           Text.Read                                 (Read (..), get, readMaybe, readP_to_Prec)
 
 config :: FilePath
 config = "bench/config.yaml"

--- a/bench/lib/Experiments.hs
+++ b/bench/lib/Experiments.hs
@@ -1,49 +1,49 @@
-{-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE ConstraintKinds           #-}
 {-# LANGUAGE ExistentialQuantification #-}
-{-# LANGUAGE ImplicitParams #-}
-{-# LANGUAGE ImpredicativeTypes #-}
+{-# LANGUAGE ImplicitParams            #-}
+{-# LANGUAGE ImpredicativeTypes        #-}
+{-# LANGUAGE RankNTypes                #-}
 
 module Experiments
-( Bench(..)
-, BenchRun(..)
-, Config(..)
-, Verbosity(..)
-, CabalStack(..)
-, SetupResult(..)
-, Example(..)
-, experiments
-, configP
-, defConfig
-, output
-, setup
-, runBench
-, exampleToOptions
-) where
-import Control.Applicative.Combinators (skipManyTill)
-import Control.Concurrent
-import Control.Exception.Safe
-import Control.Monad.Extra
-import Control.Monad.IO.Class
-import Data.Aeson (Value(Null))
-import Data.Char (isDigit)
-import Data.List
-import Data.Maybe
-import qualified Data.Text as T
-import Data.Version
-import Development.IDE.Plugin.Test
-import Experiments.Types
-import Language.Haskell.LSP.Test
-import Language.Haskell.LSP.Types
-import Language.Haskell.LSP.Types.Capabilities
-import Numeric.Natural
-import Options.Applicative
-import System.Directory
-import System.Environment.Blank (getEnv)
-import System.FilePath ((</>))
-import System.Process
-import System.Time.Extra
-import Text.ParserCombinators.ReadP (readP_to_S)
+    ( Bench (..)
+    , BenchRun (..)
+    , CabalStack (..)
+    , Config (..)
+    , Example (..)
+    , SetupResult (..)
+    , Verbosity (..)
+    , configP
+    , defConfig
+    , exampleToOptions
+    , experiments
+    , output
+    , runBench
+    , setup
+    ) where
+import           Control.Applicative.Combinators         (skipManyTill)
+import           Control.Concurrent
+import           Control.Exception.Safe
+import           Control.Monad.Extra
+import           Control.Monad.IO.Class
+import           Data.Aeson                              (Value (Null))
+import           Data.Char                               (isDigit)
+import           Data.List
+import           Data.Maybe
+import qualified Data.Text                               as T
+import           Data.Version
+import           Development.IDE.Plugin.Test
+import           Experiments.Types
+import           Language.Haskell.LSP.Test
+import           Language.Haskell.LSP.Types
+import           Language.Haskell.LSP.Types.Capabilities
+import           Numeric.Natural
+import           Options.Applicative
+import           System.Directory
+import           System.Environment.Blank                (getEnv)
+import           System.FilePath                         ((</>))
+import           System.Process
+import           System.Time.Extra
+import           Text.ParserCombinators.ReadP            (readP_to_S)
 
 hygienicEdit :: (?hygienicP :: Position) => TextDocumentContentChangeEvent
 hygienicEdit =

--- a/exe/Main.hs
+++ b/exe/Main.hs
@@ -3,53 +3,54 @@
 {-# OPTIONS_GHC -Wno-dodgy-imports #-} -- GHC no longer exports def in GHC 8.6 and above
 {-# LANGUAGE TemplateHaskell #-}
 
-module Main(main) where
+module Main
+    ( main
+    ) where
 
-import Arguments
-import Control.Concurrent.Extra
-import Control.Monad.Extra
-import Control.Lens ( (^.) )
-import Data.Default
-import Data.List.Extra
-import Data.Maybe
-import qualified Data.Text as T
-import qualified Data.Text.IO as T
-import Data.Version
-import Development.IDE.Core.Debouncer
-import Development.IDE.Core.FileStore
-import Development.IDE.Core.OfInterest
-import Development.IDE.Core.Service
-import Development.IDE.Core.Rules
-import Development.IDE.Core.Shake
-import Development.IDE.Core.RuleTypes
-import Development.IDE.LSP.Protocol
-import Development.IDE.Types.Location
-import Development.IDE.Types.Diagnostics
-import Development.IDE.Types.Options
-import Development.IDE.Types.Logger
-import Development.IDE.Plugin
-import Development.IDE.Plugin.Completions as Completions
-import Development.IDE.Plugin.CodeAction as CodeAction
-import Development.IDE.Plugin.Test as Test
-import Development.IDE.Session
-import qualified Language.Haskell.LSP.Core as LSP
-import Language.Haskell.LSP.Messages
-import Language.Haskell.LSP.Types
-import Language.Haskell.LSP.Types.Lens (params, initializationOptions)
-import Development.IDE.LSP.LanguageServer
-import qualified System.Directory.Extra as IO
-import System.Environment
-import System.IO
-import System.Info
-import System.Exit
-import System.FilePath
-import System.Time.Extra
-import Paths_ghcide
-import Development.GitRev
-import qualified Data.HashMap.Strict as HashMap
-import qualified Data.Aeson as J
-
-import HIE.Bios.Cradle
+import           Arguments
+import           Control.Concurrent.Extra
+import           Control.Lens                       ((^.))
+import           Control.Monad.Extra
+import qualified Data.Aeson                         as J
+import           Data.Default
+import qualified Data.HashMap.Strict                as HashMap
+import           Data.List.Extra
+import           Data.Maybe
+import qualified Data.Text                          as T
+import qualified Data.Text.IO                       as T
+import           Data.Version
+import           Development.GitRev
+import           Development.IDE.Core.Debouncer
+import           Development.IDE.Core.FileStore
+import           Development.IDE.Core.OfInterest
+import           Development.IDE.Core.RuleTypes
+import           Development.IDE.Core.Rules
+import           Development.IDE.Core.Service
+import           Development.IDE.Core.Shake
+import           Development.IDE.LSP.LanguageServer
+import           Development.IDE.LSP.Protocol
+import           Development.IDE.Plugin
+import           Development.IDE.Plugin.CodeAction  as CodeAction
+import           Development.IDE.Plugin.Completions as Completions
+import           Development.IDE.Plugin.Test        as Test
+import           Development.IDE.Session
+import           Development.IDE.Types.Diagnostics
+import           Development.IDE.Types.Location
+import           Development.IDE.Types.Logger
+import           Development.IDE.Types.Options
+import           HIE.Bios.Cradle
+import qualified Language.Haskell.LSP.Core          as LSP
+import           Language.Haskell.LSP.Messages
+import           Language.Haskell.LSP.Types
+import           Language.Haskell.LSP.Types.Lens    (initializationOptions, params)
+import           Paths_ghcide
+import qualified System.Directory.Extra             as IO
+import           System.Environment
+import           System.Exit
+import           System.FilePath
+import           System.IO
+import           System.Info
+import           System.Time.Extra
 
 ghcideVersion :: IO String
 ghcideVersion = do

--- a/session-loader/Development/IDE/Session.hs
+++ b/session-loader/Development/IDE/Session.hs
@@ -3,69 +3,70 @@
 {-|
 The logic for setting up a ghcide session by tapping into hie-bios.
 -}
-module Development.IDE.Session (loadSession) where
+module Development.IDE.Session
+    ( loadSession
+    ) where
 
 -- Unfortunately, we cannot use loadSession with ghc-lib since hie-bios uses
 -- the real GHC library and the types are incompatible. Furthermore, when
 -- building with ghc-lib we need to make this Haskell agnostic, so no hie-bios!
 
-import Control.Concurrent.Async
-import Control.Concurrent.Extra
-import Control.Exception.Safe
-import Control.Monad
-import Control.Monad.Extra
-import Control.Monad.IO.Class
-import qualified Crypto.Hash.SHA1 as H
-import qualified Data.ByteString.Char8 as B
-import qualified Data.HashMap.Strict as HM
-import qualified Data.Map.Strict as Map
-import qualified Data.Text as T
-import Data.Aeson
-import Data.Bifunctor
-import qualified Data.ByteString.Base16 as B16
-import Data.Either.Extra
-import Data.Function
-import Data.Hashable
-import Data.List
-import Data.IORef
-import Data.Maybe
-import Data.Time.Clock
-import Data.Version
-import Development.IDE.Core.OfInterest
-import Development.IDE.Core.Shake
-import Development.IDE.Core.RuleTypes
-import Development.IDE.GHC.Compat hiding (Target, TargetModule, TargetFile)
-import qualified Development.IDE.GHC.Compat as GHC
-import Development.IDE.GHC.Util
-import Development.IDE.Session.VersionCheck
-import Development.IDE.Types.Diagnostics
-import Development.IDE.Types.Exports
-import Development.IDE.Types.Location
-import Development.IDE.Types.Logger
-import Development.IDE.Types.Options
-import Development.Shake (Action)
-import GHC.Check
-import HIE.Bios
-import HIE.Bios.Environment hiding (getCacheDir)
-import HIE.Bios.Types
-import Hie.Implicit.Cradle (loadImplicitHieCradle)
-import Language.Haskell.LSP.Core
-import Language.Haskell.LSP.Messages
-import Language.Haskell.LSP.Types
-import System.Directory
-import qualified System.Directory.Extra as IO
-import System.FilePath
-import System.Info
-import System.IO
-
-import GHCi
-import DynFlags
-import HscTypes (ic_dflags, hsc_IC, hsc_dflags, hsc_NC)
-import Linker
-import Module
-import NameCache
-import Packages
-import Control.Exception (evaluate)
+import           Control.Concurrent.Async
+import           Control.Concurrent.Extra
+import           Control.Exception                    (evaluate)
+import           Control.Exception.Safe
+import           Control.Monad
+import           Control.Monad.Extra
+import           Control.Monad.IO.Class
+import qualified Crypto.Hash.SHA1                     as H
+import           Data.Aeson
+import           Data.Bifunctor
+import qualified Data.ByteString.Base16               as B16
+import qualified Data.ByteString.Char8                as B
+import           Data.Either.Extra
+import           Data.Function
+import qualified Data.HashMap.Strict                  as HM
+import           Data.Hashable
+import           Data.IORef
+import           Data.List
+import qualified Data.Map.Strict                      as Map
+import           Data.Maybe
+import qualified Data.Text                            as T
+import           Data.Time.Clock
+import           Data.Version
+import           Development.IDE.Core.OfInterest
+import           Development.IDE.Core.RuleTypes
+import           Development.IDE.Core.Shake
+import           Development.IDE.GHC.Compat           hiding (Target, TargetFile, TargetModule)
+import qualified Development.IDE.GHC.Compat           as GHC
+import           Development.IDE.GHC.Util
+import           Development.IDE.Session.VersionCheck
+import           Development.IDE.Types.Diagnostics
+import           Development.IDE.Types.Exports
+import           Development.IDE.Types.Location
+import           Development.IDE.Types.Logger
+import           Development.IDE.Types.Options
+import           Development.Shake                    (Action)
+import           DynFlags
+import           GHC.Check
+import           GHCi
+import           HIE.Bios
+import           HIE.Bios.Environment                 hiding (getCacheDir)
+import           HIE.Bios.Types
+import           Hie.Implicit.Cradle                  (loadImplicitHieCradle)
+import           HscTypes                             (hsc_IC, hsc_NC, hsc_dflags, ic_dflags)
+import           Language.Haskell.LSP.Core
+import           Language.Haskell.LSP.Messages
+import           Language.Haskell.LSP.Types
+import           Linker
+import           Module
+import           NameCache
+import           Packages
+import           System.Directory
+import qualified System.Directory.Extra               as IO
+import           System.FilePath
+import           System.IO
+import           System.Info
 
 -- | Given a root directory, return a Shake 'Action' which setups an
 -- 'IdeGhcSession' given a file.

--- a/src/Development/IDE.hs
+++ b/src/Development/IDE.hs
@@ -1,46 +1,27 @@
 module Development.IDE
-(
-    -- TODO It would be much nicer to enumerate all the exports
-    -- and organize them in sections
-    module X
+    ( -- TODO It would be much nicer to enumerate all the exports
+      -- and organize them in sections
+      module X
+    ) where
 
-) where
-
-import Development.IDE.Core.RuleTypes as X
-import Development.IDE.Core.Rules as X
-  (GhcSessionIO(..)
-  ,getAtPoint
-  ,getDefinition
-  ,getParsedModule
-  ,getTypeDefinition
-  )
-import Development.IDE.Core.FileExists as X
-  (getFileExists)
-import Development.IDE.Core.FileStore as X
-  (getFileContents)
-import Development.IDE.Core.IdeConfiguration as X
-  (IdeConfiguration(..)
-  ,isWorkspaceFile)
-import Development.IDE.Core.OfInterest as X (getFilesOfInterest)
-import Development.IDE.Core.Service as X (runAction)
-import Development.IDE.Core.Shake as X
-  ( IdeState,
-    shakeExtras,
-    ShakeExtras,
-    IdeRule,
-    define, defineEarlyCutoff,
-    GetModificationTime(GetModificationTime),
-    use, useNoFile, uses, useWithStale, useWithStaleFast, useWithStaleFast',
-    FastResult(..),
-    use_, useNoFile_, uses_, useWithStale_,
-    ideLogger,
-    actionLogger,
-    IdeAction(..), runIdeAction
-  )
-import Development.IDE.GHC.Error as X
-import Development.IDE.GHC.Util as X
-import Development.IDE.Plugin as X
-import Development.IDE.Types.Diagnostics as X
-import Development.IDE.Types.Location as X
-import Development.IDE.Types.Logger as X
-import Development.Shake as X (Action, action, Rules, RuleResult)
+import           Development.IDE.Core.FileExists       as X (getFileExists)
+import           Development.IDE.Core.FileStore        as X (getFileContents)
+import           Development.IDE.Core.IdeConfiguration as X (IdeConfiguration (..), isWorkspaceFile)
+import           Development.IDE.Core.OfInterest       as X (getFilesOfInterest)
+import           Development.IDE.Core.RuleTypes        as X
+import           Development.IDE.Core.Rules            as X (GhcSessionIO (..), getAtPoint, getDefinition,
+                                                             getParsedModule, getTypeDefinition)
+import           Development.IDE.Core.Service          as X (runAction)
+import           Development.IDE.Core.Shake            as X (FastResult (..), GetModificationTime (GetModificationTime),
+                                                             IdeAction (..), IdeRule, IdeState, ShakeExtras,
+                                                             actionLogger, define, defineEarlyCutoff, ideLogger,
+                                                             runIdeAction, shakeExtras, use, useNoFile, useNoFile_,
+                                                             useWithStale, useWithStaleFast, useWithStaleFast',
+                                                             useWithStale_, use_, uses, uses_)
+import           Development.IDE.GHC.Error             as X
+import           Development.IDE.GHC.Util              as X
+import           Development.IDE.Plugin                as X
+import           Development.IDE.Types.Diagnostics     as X
+import           Development.IDE.Types.Location        as X
+import           Development.IDE.Types.Logger          as X
+import           Development.Shake                     as X (Action, RuleResult, Rules, action)

--- a/src/Development/IDE/Core/Debouncer.hs
+++ b/src/Development/IDE/Core/Debouncer.hs
@@ -3,19 +3,19 @@
 
 module Development.IDE.Core.Debouncer
     ( Debouncer
-    , registerEvent
     , newAsyncDebouncer
     , noopDebouncer
+    , registerEvent
     ) where
 
-import Control.Concurrent.Extra
-import Control.Concurrent.Async
-import Control.Exception
-import Control.Monad.Extra
-import Data.Hashable
-import Data.HashMap.Strict (HashMap)
-import qualified Data.HashMap.Strict as Map
-import System.Time.Extra
+import           Control.Concurrent.Async
+import           Control.Concurrent.Extra
+import           Control.Exception
+import           Control.Monad.Extra
+import           Data.HashMap.Strict      (HashMap)
+import qualified Data.HashMap.Strict      as Map
+import           Data.Hashable
+import           System.Time.Extra
 
 -- | A debouncer can be used to avoid triggering many events
 -- (e.g. diagnostics) for the same key (e.g. the same file)

--- a/src/Development/IDE/Core/FileStore.hs
+++ b/src/Development/IDE/Core/FileStore.hs
@@ -1,69 +1,69 @@
 -- Copyright (c) 2019 The DAML Authors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
-{-# LANGUAGE CPP #-}
+{-# LANGUAGE CPP          #-}
 {-# LANGUAGE TypeFamilies #-}
 
-module Development.IDE.Core.FileStore(
-    getFileContents,
-    getVirtualFile,
-    setFileModified,
-    setSomethingModified,
-    fileStoreRules,
-    modificationTime,
-    typecheckParents,
-    VFSHandle,
-    makeVFSHandle,
-    makeLSPVFSHandle,
-    isFileOfInterestRule
+module Development.IDE.Core.FileStore
+    ( VFSHandle
+    , fileStoreRules
+    , getFileContents
+    , getVirtualFile
+    , isFileOfInterestRule
+    , makeLSPVFSHandle
+    , makeVFSHandle
+    , modificationTime
+    , setFileModified
+    , setSomethingModified
+    , typecheckParents
     ) where
 
-import Development.IDE.GHC.Orphans()
-import           Development.IDE.Core.Shake
-import Control.Concurrent.Extra
-import qualified Data.Map.Strict as Map
-import qualified Data.HashMap.Strict as HM
-import Data.Maybe
-import qualified Data.Text as T
+import           Control.Concurrent.Extra
+import           Control.Exception
 import           Control.Monad.Extra
+import qualified Data.ByteString.Char8                        as BS
+import           Data.Either.Extra
+import qualified Data.HashMap.Strict                          as HM
+import           Data.Int                                     (Int64)
+import qualified Data.Map.Strict                              as Map
+import           Data.Maybe
+import qualified Data.Rope.UTF16                              as Rope
+import qualified Data.Text                                    as T
+import           Data.Time
+import           Development.IDE.Core.OfInterest              (getFilesOfInterest, kick)
+import           Development.IDE.Core.RuleTypes
+import           Development.IDE.Core.Shake
+import           Development.IDE.GHC.Orphans                  ()
+import           Development.IDE.Import.DependencyInformation
+import           Development.IDE.Types.Diagnostics
+import           Development.IDE.Types.Location
+import           Development.IDE.Types.Options
 import           Development.Shake
 import           Development.Shake.Classes
-import           Control.Exception
 import           GHC.Generics
-import Data.Either.Extra
-import Data.Int (Int64)
-import Data.Time
-import System.IO.Error
-import qualified Data.ByteString.Char8 as BS
-import Development.IDE.Types.Diagnostics
-import Development.IDE.Types.Location
-import Development.IDE.Core.OfInterest (getFilesOfInterest, kick)
-import Development.IDE.Core.RuleTypes
-import Development.IDE.Types.Options
-import qualified Data.Rope.UTF16 as Rope
-import Development.IDE.Import.DependencyInformation
+import           System.IO.Error
 
 #ifdef mingw32_HOST_OS
-import qualified System.Directory as Dir
+import qualified System.Directory                             as Dir
 #else
-import Data.Time.Clock.System (systemToUTCTime, SystemTime(MkSystemTime))
-import Foreign.Ptr
-import Foreign.C.String
-import Foreign.C.Types
-import Foreign.Marshal (alloca)
-import Foreign.Storable
-import qualified System.Posix.Error as Posix
+import           Data.Time.Clock.System                       (SystemTime (MkSystemTime), systemToUTCTime)
+import           Foreign.C.String
+import           Foreign.C.Types
+import           Foreign.Marshal                              (alloca)
+import           Foreign.Ptr
+import           Foreign.Storable
+import qualified System.Posix.Error                           as Posix
 #endif
 
-import qualified Development.IDE.Types.Logger as L
+import qualified Development.IDE.Types.Logger                 as L
 
-import Language.Haskell.LSP.Core
-import Language.Haskell.LSP.VFS
+import           Language.Haskell.LSP.Core
+import           Language.Haskell.LSP.VFS
 
 -- | haskell-lsp manages the VFS internally and automatically so we cannot use
 -- the builtin VFS without spawning up an LSP server. To be able to test things
 -- like `setBufferModified` we abstract over the VFS implementation.
 data VFSHandle = VFSHandle
-    { getVirtualFile :: NormalizedUri -> IO (Maybe VirtualFile)
+    { getVirtualFile         :: NormalizedUri -> IO (Maybe VirtualFile)
         -- ^ get the contents of a virtual file
     , setVirtualFileContents :: Maybe (NormalizedUri -> Maybe T.Text -> IO ())
         -- ^ set a specific file to a value. If Nothing then we are ignoring these
@@ -179,7 +179,7 @@ getFileContentsRule vfs =
             mbVirtual <- getVirtualFile vfs $ filePathToUri' file
             pure $ Rope.toText . _text <$> mbVirtual
         case res of
-            Left err -> return ([err], Nothing)
+            Left err       -> return ([err], Nothing)
             Right contents -> return ([], Just (time, contents))
 
 ideTryIOException :: NormalizedFilePath -> IO a -> IO (Either FileDiagnostic a)
@@ -220,9 +220,9 @@ setFileModified :: IdeState
 setFileModified state saved nfp = do
     ideOptions <- getIdeOptionsIO $ shakeExtras state
     let checkParents = case optCheckParents ideOptions of
-          AlwaysCheck -> True
+          AlwaysCheck         -> True
           CheckOnSaveAndClose -> saved
-          _ -> False
+          _                   -> False
     VFSHandle{..} <- getIdeGlobalState state
     when (isJust setVirtualFileContents) $
         fail "setFileModified can't be called on this type of VFSHandle"

--- a/src/Development/IDE/Core/IdeConfiguration.hs
+++ b/src/Development/IDE/Core/IdeConfiguration.hs
@@ -14,20 +14,20 @@ where
 
 import           Control.Concurrent.Extra
 import           Control.Monad
-import           Data.Hashable                  (Hashed, hashed, unhashed)
-import           Data.HashSet                   (HashSet, singleton)
-import           Data.Text                      (Text, isPrefixOf)
 import           Data.Aeson.Types               (Value)
+import           Data.HashSet                   (HashSet, singleton)
+import           Data.Hashable                  (Hashed, hashed, unhashed)
+import           Data.Text                      (Text, isPrefixOf)
 import           Development.IDE.Core.Shake
 import           Development.IDE.Types.Location
 import           Development.Shake
 import           Language.Haskell.LSP.Types
-import           System.FilePath (isRelative)
+import           System.FilePath                (isRelative)
 
 -- | Lsp client relevant configuration details
 data IdeConfiguration = IdeConfiguration
   { workspaceFolders :: HashSet NormalizedUri
-  , clientSettings :: Hashed (Maybe Value)
+  , clientSettings   :: Hashed (Maybe Value)
   }
   deriving (Show)
 

--- a/src/Development/IDE/Core/OfInterest.hs
+++ b/src/Development/IDE/Core/OfInterest.hs
@@ -1,38 +1,40 @@
 -- Copyright (c) 2019 The DAML Authors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE TypeFamilies      #-}
 
 -- | Utilities and state for the files of interest - those which are currently
 --   open in the editor. The useful function is 'getFilesOfInterest'.
-module Development.IDE.Core.OfInterest(
-    ofInterestRules,
-    getFilesOfInterest, setFilesOfInterest, modifyFilesOfInterest,
-    kick, FileOfInterestStatus(..)
+module Development.IDE.Core.OfInterest
+    ( FileOfInterestStatus (..)
+    , getFilesOfInterest
+    , kick
+    , modifyFilesOfInterest
+    , ofInterestRules
+    , setFilesOfInterest
     ) where
 
-import Control.Concurrent.Extra
-import Data.Binary
-import Data.Hashable
-import Control.DeepSeq
-import GHC.Generics
-import Data.Typeable
-import qualified Data.ByteString.UTF8 as BS
-import Control.Exception
-import Data.HashMap.Strict (HashMap)
-import qualified Data.HashMap.Strict as HashMap
-import qualified Data.Text as T
-import Data.Tuple.Extra
-import Development.Shake
-import Control.Monad (void)
-
-import Development.IDE.Types.Exports
-import Development.IDE.Types.Location
-import Development.IDE.Types.Logger
-import Development.IDE.Core.RuleTypes
-import Development.IDE.Core.Shake
-import Data.Maybe (catMaybes)
+import           Control.Concurrent.Extra
+import           Control.DeepSeq
+import           Control.Exception
+import           Control.Monad                  (void)
+import           Data.Binary
+import qualified Data.ByteString.UTF8           as BS
+import           Data.HashMap.Strict            (HashMap)
+import qualified Data.HashMap.Strict            as HashMap
+import           Data.Hashable
+import           Data.Maybe                     (catMaybes)
+import qualified Data.Text                      as T
+import           Data.Tuple.Extra
+import           Data.Typeable
+import           Development.IDE.Core.RuleTypes
+import           Development.IDE.Core.Shake
+import           Development.IDE.Types.Exports
+import           Development.IDE.Types.Location
+import           Development.IDE.Types.Logger
+import           Development.Shake
+import           GHC.Generics
 
 newtype OfInterestVar = OfInterestVar (Var (HashMap NormalizedFilePath FileOfInterestStatus))
 instance IsIdeGlobal OfInterestVar

--- a/src/Development/IDE/Core/PositionMapping.hs
+++ b/src/Development/IDE/Core/PositionMapping.hs
@@ -1,29 +1,29 @@
 -- Copyright (c) 2019 The DAML Authors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 module Development.IDE.Core.PositionMapping
-  ( PositionMapping(..)
-  , PositionResult(..)
-  , lowerRange
-  , upperRange
-  , positionResultToMaybe
-  , fromCurrentPosition
-  , toCurrentPosition
-  , PositionDelta(..)
-  , addDelta
-  , mkDelta
-  , toCurrentRange
-  , fromCurrentRange
-  , applyChange
-  , zeroMapping
-  -- toCurrent and fromCurrent are mainly exposed for testing
-  , toCurrent
-  , fromCurrent
-  ) where
+    ( PositionDelta (..)
+    , PositionMapping (..)
+    , PositionResult (..)
+    , addDelta
+    , applyChange
+    , fromCurrentPosition
+    , fromCurrentRange
+    , lowerRange
+    , mkDelta
+    , positionResultToMaybe
+    , toCurrentPosition
+    , toCurrentRange
+    , upperRange
+    , zeroMapping
+      -- toCurrent and fromCurrent are mainly exposed for testing
+    , fromCurrent
+    , toCurrent
+    ) where
 
-import Control.Monad
-import qualified Data.Text as T
-import Language.Haskell.LSP.Types
-import Data.List
+import           Control.Monad
+import           Data.List
+import qualified Data.Text                  as T
+import           Language.Haskell.LSP.Types
 
 -- | Either an exact position, or the range of text that was substituted
 data PositionResult a
@@ -34,16 +34,16 @@ data PositionResult a
   deriving (Eq,Ord,Show,Functor)
 
 lowerRange :: PositionResult a -> a
-lowerRange (PositionExact a) = a
+lowerRange (PositionExact a)       = a
 lowerRange (PositionRange lower _) = lower
 
 upperRange :: PositionResult a -> a
-upperRange (PositionExact a) = a
+upperRange (PositionExact a)       = a
 upperRange (PositionRange _ upper) = upper
 
 positionResultToMaybe :: PositionResult a -> Maybe a
 positionResultToMaybe (PositionExact a) = Just a
-positionResultToMaybe _ = Nothing
+positionResultToMaybe _                 = Nothing
 
 instance Applicative PositionResult where
   pure = PositionExact
@@ -60,7 +60,7 @@ instance Monad PositionResult where
 
 -- The position delta is the difference between two versions
 data PositionDelta = PositionDelta
-  { toDelta :: !(Position -> PositionResult Position)
+  { toDelta   :: !(Position -> PositionResult Position)
   , fromDelta :: !(Position -> PositionResult Position)
   }
 

--- a/src/Development/IDE/Core/Preprocessor.hs
+++ b/src/Development/IDE/Core/Preprocessor.hs
@@ -2,37 +2,36 @@
 -- SPDX-License-Identifier: Apache-2.0
 
 module Development.IDE.Core.Preprocessor
-  ( preprocessor
-  ) where
+    ( preprocessor
+    ) where
 
-import Development.IDE.GHC.CPP
-import Development.IDE.GHC.Orphans()
-import Development.IDE.GHC.Compat
-import GhcMonad
-import StringBuffer as SB
-
-import Data.List.Extra
-import System.FilePath
-import System.IO.Extra
-import Data.Char
-import DynFlags
-import qualified HeaderInfo as Hdr
-import Development.IDE.Types.Diagnostics
-import Development.IDE.Types.Location
-import Development.IDE.GHC.Error
-import SysTools (Option (..), runUnlit, runPp)
-import Control.Monad.Trans.Except
-import qualified GHC.LanguageExtensions as LangExt
-import Data.Maybe
-import Control.Exception.Safe (catch, throw)
-import Data.IORef (IORef, modifyIORef, newIORef, readIORef)
-import Data.Text (Text)
-import qualified Data.Text as T
-import Outputable (showSDoc)
-import Control.DeepSeq (NFData(rnf))
-import Control.Exception (evaluate)
-import Control.Monad.IO.Class (MonadIO)
-import Exception (ExceptionMonad)
+import           Control.DeepSeq                   (NFData (rnf))
+import           Control.Exception                 (evaluate)
+import           Control.Exception.Safe            (catch, throw)
+import           Control.Monad.IO.Class            (MonadIO)
+import           Control.Monad.Trans.Except
+import           Data.Char
+import           Data.IORef                        (IORef, modifyIORef, newIORef, readIORef)
+import           Data.List.Extra
+import           Data.Maybe
+import           Data.Text                         (Text)
+import qualified Data.Text                         as T
+import           Development.IDE.GHC.CPP
+import           Development.IDE.GHC.Compat
+import           Development.IDE.GHC.Error
+import           Development.IDE.GHC.Orphans       ()
+import           Development.IDE.Types.Diagnostics
+import           Development.IDE.Types.Location
+import           DynFlags
+import           Exception                         (ExceptionMonad)
+import qualified GHC.LanguageExtensions            as LangExt
+import           GhcMonad
+import qualified HeaderInfo                        as Hdr
+import           Outputable                        (showSDoc)
+import           StringBuffer                      as SB
+import           SysTools                          (Option (..), runPp, runUnlit)
+import           System.FilePath
+import           System.IO.Extra
 
 
 -- | Given a file and some contents, apply any necessary preprocessors,

--- a/src/Development/IDE/Core/RuleTypes.hs
+++ b/src/Development/IDE/Core/RuleTypes.hs
@@ -1,40 +1,38 @@
 -- Copyright (c) 2019 The DAML Authors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleInstances  #-}
+{-# LANGUAGE TypeFamilies       #-}
 
 -- | A Shake implementation of the compiler service, built
 --   using the "Shaker" abstraction layer for in-memory use.
 --
-module Development.IDE.Core.RuleTypes(
-    module Development.IDE.Core.RuleTypes
+module Development.IDE.Core.RuleTypes
+    ( module Development.IDE.Core.RuleTypes
     ) where
 
 import           Control.DeepSeq
-import Data.Aeson.Types (Value)
-import Data.Binary
-import           Development.IDE.Import.DependencyInformation
-import Development.IDE.GHC.Compat hiding (HieFileResult)
-import Development.IDE.GHC.Util
-import Development.IDE.Core.Shake (KnownTargets)
+import           Data.Aeson.Types                             (Value)
+import           Data.Binary
+import           Data.ByteString                              (ByteString)
 import           Data.Hashable
+import qualified Data.Map                                     as M
+import qualified Data.Set                                     as S
 import           Data.Typeable
-import qualified Data.Set as S
-import qualified Data.Map as M
-import           Development.Shake
-import           GHC.Generics                             (Generic)
-
-import Module (InstalledUnitId)
-import HscTypes (ModGuts, hm_iface, HomeModInfo)
-
+import           Development.IDE.Core.Shake                   (KnownTargets)
+import           Development.IDE.GHC.Compat                   hiding (HieFileResult)
+import           Development.IDE.GHC.Util
+import           Development.IDE.Import.DependencyInformation
+import           Development.IDE.Import.FindImports           (ArtifactsLocation)
 import           Development.IDE.Spans.Common
 import           Development.IDE.Spans.LocalBindings
-import           Development.IDE.Import.FindImports (ArtifactsLocation)
-import Data.ByteString (ByteString)
-import Language.Haskell.LSP.Types (NormalizedFilePath)
-import TcRnMonad (TcGblEnv)
+import           Development.Shake
+import           GHC.Generics                                 (Generic)
+import           HscTypes                                     (HomeModInfo, ModGuts, hm_iface)
+import           Language.Haskell.LSP.Types                   (NormalizedFilePath)
+import           Module                                       (InstalledUnitId)
+import           TcRnMonad                                    (TcGblEnv)
 
 -- NOTATION
 --   Foo+ means Foo for the dependencies
@@ -132,10 +130,10 @@ data HieAstResult
   -- Lazyness can't cause leaks here because the lifetime of `refMap` will be the same
   -- as that of `hieAst`
   }
- 
+
 instance NFData HieAstResult where
     rnf (HAR m hf _rm) = rnf m `seq` rwhnf hf
- 
+
 instance Show HieAstResult where
     show = show . hieModule
 

--- a/src/Development/IDE/Core/Service.hs
+++ b/src/Development/IDE/Core/Service.hs
@@ -1,37 +1,40 @@
 -- Copyright (c) 2019 The DAML Authors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-{-# LANGUAGE TypeFamilies               #-}
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE RankNTypes        #-}
+{-# LANGUAGE TypeFamilies      #-}
 
 -- | A Shake implementation of the compiler service, built
 --   using the "Shaker" abstraction layer for in-memory use.
 --
-module Development.IDE.Core.Service(
-    getIdeOptions, getIdeOptionsIO,
-    IdeState, initialise, shutdown,
-    runAction,
-    writeProfile,
-    getDiagnostics, unsafeClearDiagnostics,
-    ideLogger,
-    updatePositionMapping,
+module Development.IDE.Core.Service
+    ( IdeState
+    , getDiagnostics
+    , getIdeOptions
+    , getIdeOptionsIO
+    , ideLogger
+    , initialise
+    , runAction
+    , shutdown
+    , unsafeClearDiagnostics
+    , updatePositionMapping
+    , writeProfile
     ) where
 
-import Data.Maybe
-import Development.IDE.Types.Options (IdeOptions(..))
-import Development.IDE.Core.Debouncer
-import           Development.IDE.Core.FileStore  (VFSHandle, fileStoreRules)
-import           Development.IDE.Core.FileExists (fileExistsRules)
+import           Control.Monad
+import           Data.Maybe
+import           Development.IDE.Core.Debouncer
+import           Development.IDE.Core.FileExists         (fileExistsRules)
+import           Development.IDE.Core.FileStore          (VFSHandle, fileStoreRules)
 import           Development.IDE.Core.OfInterest
-import Development.IDE.Types.Logger as Logger
-import           Development.Shake
-import qualified Language.Haskell.LSP.Messages as LSP
-import qualified Language.Haskell.LSP.Types as LSP
-import qualified Language.Haskell.LSP.Types.Capabilities as LSP
-
 import           Development.IDE.Core.Shake
-import Control.Monad
+import           Development.IDE.Types.Logger            as Logger
+import           Development.IDE.Types.Options           (IdeOptions (..))
+import           Development.Shake
+import qualified Language.Haskell.LSP.Messages           as LSP
+import qualified Language.Haskell.LSP.Types              as LSP
+import qualified Language.Haskell.LSP.Types.Capabilities as LSP
 
 
 

--- a/src/Development/IDE/GHC/CPP.hs
+++ b/src/Development/IDE/GHC/CPP.hs
@@ -7,7 +7,10 @@
 
 {- HLINT ignore -} -- since copied from upstream
 
-{-# LANGUAGE CPP, NamedFieldPuns, NondecreasingIndentation, BangPatterns, MultiWayIf #-}
+{-# LANGUAGE CPP                      #-}
+{-# LANGUAGE MultiWayIf               #-}
+{-# LANGUAGE NamedFieldPuns           #-}
+{-# LANGUAGE NondecreasingIndentation #-}
 {-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
 #include "ghc-api-version.h"
 
@@ -19,33 +22,35 @@
 --
 -----------------------------------------------------------------------------
 
-module Development.IDE.GHC.CPP(doCpp, addOptP)
-where
+module Development.IDE.GHC.CPP
+    ( addOptP
+    , doCpp
+    ) where
 
-import Development.IDE.GHC.Compat
-import Packages
-import SysTools
-import Module
-import DynFlags
-import Panic
-import FileCleanup
+import           Development.IDE.GHC.Compat
+import           DynFlags
+import           FileCleanup
+import           Module
+import           Packages
+import           Panic
+import           SysTools
 #if MIN_GHC_API_VERSION(8,8,2)
-import LlvmCodeGen (llvmVersionList)
+import           LlvmCodeGen                (llvmVersionList)
 #elif MIN_GHC_API_VERSION(8,8,0)
-import LlvmCodeGen (LlvmVersion (..))
+import           LlvmCodeGen                (LlvmVersion (..))
 #endif
 #if MIN_GHC_API_VERSION (8,10,0)
-import Fingerprint
-import ToolSettings
+import           Fingerprint
+import           ToolSettings
 #endif
 
-import System.Directory
-import System.FilePath
-import Control.Monad
-import System.Info
-import Data.List        ( intercalate )
-import Data.Maybe
-import Data.Version
+import           Control.Monad
+import           Data.List                  (intercalate)
+import           Data.Maybe
+import           Data.Version
+import           System.Directory
+import           System.FilePath
+import           System.Info
 
 
 

--- a/src/Development/IDE/GHC/Error.hs
+++ b/src/Development/IDE/GHC/Error.hs
@@ -1,45 +1,42 @@
 -- Copyright (c) 2019 The DAML Authors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 module Development.IDE.GHC.Error
-  (
-    -- * Producing Diagnostic values
-    diagFromErrMsgs
-  , diagFromErrMsg
-  , diagFromString
-  , diagFromStrings
-  , diagFromGhcException
-  , catchSrcErrors
+    ( -- * Producing Diagnostic values
+      catchSrcErrors
+    , diagFromErrMsg
+    , diagFromErrMsgs
+    , diagFromGhcException
+    , diagFromString
+    , diagFromStrings
+      -- * utilities working with spans
+    , isInsideSrcSpan
+    , noSpan
+    , realSpan
+    , realSrcLocToPosition
+    , realSrcSpanToRange
+    , srcSpanToFilename
+    , srcSpanToLocation
+    , srcSpanToRange
+    , zeroSpan
+      -- * utilities working with severities
+    , toDSeverity
+    ) where
 
-  -- * utilities working with spans
-  , srcSpanToLocation
-  , srcSpanToRange
-  , realSrcSpanToRange
-  , realSrcLocToPosition
-  , srcSpanToFilename
-  , zeroSpan
-  , realSpan
-  , isInsideSrcSpan
-  , noSpan
-
-  -- * utilities working with severities
-  , toDSeverity
-  ) where
-
-import                     Development.IDE.Types.Diagnostics as D
-import qualified           Data.Text as T
-import Data.Maybe
-import Development.IDE.Types.Location
-import Development.IDE.GHC.Orphans()
-import qualified FastString as FS
-import           GHC
 import           Bag
-import DynFlags
-import HscTypes
-import Panic
+import           Data.Maybe
+import qualified Data.Text                         as T
+import           Development.IDE.GHC.Orphans       ()
+import           Development.IDE.Types.Diagnostics as D
+import           Development.IDE.Types.Location
+import           DynFlags
 import           ErrUtils
+import           Exception                         (ExceptionMonad)
+import qualified FastString                        as FS
+import           GHC
+import           HscTypes
+import qualified Outputable                        as Out
+import           Panic
 import           SrcLoc
-import qualified Outputable                 as Out
-import Exception (ExceptionMonad)
 
 
 

--- a/src/Development/IDE/GHC/Orphans.hs
+++ b/src/Development/IDE/GHC/Orphans.hs
@@ -8,7 +8,9 @@
 
 -- | Orphan instances for GHC.
 --   Note that the 'NFData' instances may not be law abiding.
-module Development.IDE.GHC.Orphans() where
+module Development.IDE.GHC.Orphans
+    (
+    ) where
 
 import           Bag
 import           Control.DeepSeq

--- a/src/Development/IDE/GHC/Util.hs
+++ b/src/Development/IDE/GHC/Util.hs
@@ -2,79 +2,82 @@
 -- SPDX-License-Identifier: Apache-2.0
 
 -- | General utility functions, mostly focused around GHC operations.
-module Development.IDE.GHC.Util(
-    -- * HcsEnv and environment
-    HscEnvEq,
-    hscEnv, newHscEnvEq,
-    hscEnvWithImportPaths,
-    envImportPaths,
-    modifyDynFlags,
-    evalGhcEnv,
-    runGhcEnv,
-    deps,
-    -- * GHC wrappers
-    prettyPrint,
-    printRdrName,
-    printName,
-    ParseResult(..), runParser,
-    lookupPackageConfig,
-    textToStringBuffer,
-    bytestringToStringBuffer,
-    stringBufferToByteString,
-    moduleImportPath,
-    cgGutsToCoreModule,
-    fingerprintToBS,
-    fingerprintFromStringBuffer,
-    -- * General utilities
-    readFileUtf8,
-    hDuplicateTo',
-    setHieDir,
-    dontWriteHieFiles,
-    disableWarningsAsErrors,
-    newHscEnvEqPreserveImportPaths) where
+module Development.IDE.GHC.Util
+    ( -- * HcsEnv and environment
+      HscEnvEq
+    , deps
+    , envImportPaths
+    , evalGhcEnv
+    , hscEnv
+    , hscEnvWithImportPaths
+    , modifyDynFlags
+    , newHscEnvEq
+    , runGhcEnv
+      -- * GHC wrappers
+    , ParseResult (..)
+    , bytestringToStringBuffer
+    , cgGutsToCoreModule
+    , fingerprintFromStringBuffer
+    , fingerprintToBS
+    , lookupPackageConfig
+    , moduleImportPath
+    , prettyPrint
+    , printName
+    , printRdrName
+    , runParser
+    , stringBufferToByteString
+    , textToStringBuffer
+      -- * General utilities
+    , disableWarningsAsErrors
+    , dontWriteHieFiles
+    , hDuplicateTo'
+    , newHscEnvEqPreserveImportPaths
+    , readFileUtf8
+    , setHieDir
+    ) where
 
-import Control.Concurrent
-import Data.List.Extra
-import Data.ByteString.Internal (ByteString(..))
-import Data.Maybe
-import Data.Typeable
-import qualified Data.ByteString.Internal as BS
-import Fingerprint
-import GhcMonad
-import Control.Exception
-import Data.IORef
-import FileCleanup
-import Foreign.Ptr
-import Foreign.ForeignPtr
-import Foreign.Storable
-import GHC.IO.BufferedIO (BufferedIO)
-import GHC.IO.Device as IODevice
-import GHC.IO.Encoding
-import GHC.IO.Exception
-import GHC.IO.Handle.Types
-import GHC.IO.Handle.Internals
-import Data.Unique
-import Development.Shake.Classes
-import qualified Data.Text                as T
-import qualified Data.Text.Encoding       as T
-import qualified Data.Text.Encoding.Error as T
-import qualified Data.ByteString          as BS
-import Lexer
-import StringBuffer
-import System.FilePath
-import HscTypes (cg_binds, md_types, cg_module, ModDetails, CgGuts, ic_dflags, hsc_IC, HscEnv(hsc_dflags))
-import PackageConfig (PackageConfig)
-import Outputable (showSDocUnsafe, ppr, showSDoc, Outputable)
-import Packages (getPackageConfigMap, lookupPackage')
-import SrcLoc (mkRealSrcLoc)
-import FastString (mkFastString)
-import DynFlags (emptyFilesToClean, unsafeGlobalDynFlags)
-import Module (moduleNameSlashes, InstalledUnitId)
-import OccName (parenSymOcc)
-import RdrName (nameRdrName, rdrNameOcc)
-
-import Development.IDE.GHC.Compat as GHC
-import Development.IDE.Types.Location
+import           Control.Concurrent
+import           Control.Exception
+import qualified Data.ByteString                as BS
+import           Data.ByteString.Internal       (ByteString (..))
+import qualified Data.ByteString.Internal       as BS
+import           Data.IORef
+import           Data.List.Extra
+import           Data.Maybe
+import qualified Data.Text                      as T
+import qualified Data.Text.Encoding             as T
+import qualified Data.Text.Encoding.Error       as T
+import           Data.Typeable
+import           Data.Unique
+import           Development.IDE.GHC.Compat     as GHC
+import           Development.IDE.Types.Location
+import           Development.Shake.Classes
+import           DynFlags                       (emptyFilesToClean, unsafeGlobalDynFlags)
+import           FastString                     (mkFastString)
+import           FileCleanup
+import           Fingerprint
+import           Foreign.ForeignPtr
+import           Foreign.Ptr
+import           Foreign.Storable
+import           GHC.IO.BufferedIO              (BufferedIO)
+import           GHC.IO.Device                  as IODevice
+import           GHC.IO.Encoding
+import           GHC.IO.Exception
+import           GHC.IO.Handle.Internals
+import           GHC.IO.Handle.Types
+import           GhcMonad
+import           HscTypes                       (CgGuts, HscEnv (hsc_dflags), ModDetails, cg_binds, cg_module, hsc_IC,
+                                                 ic_dflags, md_types)
+import           Lexer
+import           Module                         (InstalledUnitId, moduleNameSlashes)
+import           OccName                        (parenSymOcc)
+import           Outputable                     (Outputable, ppr, showSDoc, showSDocUnsafe)
+import           PackageConfig                  (PackageConfig)
+import           Packages                       (getPackageConfigMap, lookupPackage')
+import           RdrName                        (nameRdrName, rdrNameOcc)
+import           SrcLoc                         (mkRealSrcLoc)
+import           StringBuffer
+import           System.FilePath
 
 
 ----------------------------------------------------------------------

--- a/src/Development/IDE/GHC/Warnings.hs
+++ b/src/Development/IDE/GHC/Warnings.hs
@@ -1,19 +1,19 @@
 -- Copyright (c) 2019 The DAML Authors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-module Development.IDE.GHC.Warnings(withWarnings) where
-
-import GhcMonad
-import ErrUtils
-import GhcPlugins as GHC hiding (Var)
+module Development.IDE.GHC.Warnings
+    ( withWarnings
+    ) where
 
 import           Control.Concurrent.Extra
 import           Control.Monad.Extra
-import qualified           Data.Text as T
-
-import           Development.IDE.Types.Diagnostics
-import Development.IDE.GHC.Util
+import qualified Data.Text                         as T
 import           Development.IDE.GHC.Error
+import           Development.IDE.GHC.Util
+import           Development.IDE.Types.Diagnostics
+import           ErrUtils
+import           GhcMonad
+import           GhcPlugins                        as GHC hiding (Var)
 
 
 -- | Take a GHC monadic action (e.g. @typecheckModule pm@ for some

--- a/src/Development/IDE/GHC/WithDynFlags.hs
+++ b/src/Development/IDE/GHC/WithDynFlags.hs
@@ -1,14 +1,14 @@
 module Development.IDE.GHC.WithDynFlags
-( WithDynFlags
-, evalWithDynFlags
-) where
+    ( WithDynFlags
+    , evalWithDynFlags
+    ) where
 
-import Control.Monad.Trans.Reader (ask, ReaderT(..))
-import GHC (DynFlags)
-import Control.Monad.IO.Class (MonadIO)
-import Exception (ExceptionMonad(..))
-import Control.Monad.Trans.Class (MonadTrans(..))
-import GhcPlugins (HasDynFlags(..))
+import           Control.Monad.IO.Class     (MonadIO)
+import           Control.Monad.Trans.Class  (MonadTrans (..))
+import           Control.Monad.Trans.Reader (ReaderT (..), ask)
+import           Exception                  (ExceptionMonad (..))
+import           GHC                        (DynFlags)
+import           GhcPlugins                 (HasDynFlags (..))
 
 -- | A monad transformer implementing the 'HasDynFlags' effect
 newtype WithDynFlags m a = WithDynFlags {withDynFlags :: ReaderT DynFlags m a}

--- a/src/Development/IDE/Import/DependencyInformation.hs
+++ b/src/Development/IDE/Import/DependencyInformation.hs
@@ -2,60 +2,56 @@
 -- SPDX-License-Identifier: Apache-2.0
 
 module Development.IDE.Import.DependencyInformation
-  ( DependencyInformation(..)
-  , ModuleImports(..)
-  , RawDependencyInformation(..)
-  , NodeError(..)
-  , ModuleParseError(..)
-  , TransitiveDependencies(..)
-  , FilePathId(..)
-  , NamedModuleDep(..)
+    ( BootIdMap
+    , DependencyInformation (..)
+    , FilePathId (..)
+    , ModuleImports (..)
+    , ModuleParseError (..)
+    , NamedModuleDep (..)
+    , NodeError (..)
+    , PathIdMap
+    , RawDependencyInformation (..)
+    , TransitiveDependencies (..)
+    , emptyPathIdMap
+    , getPathId
+    , idToPath
+    , immediateReverseDependencies
+    , insertBootId
+    , insertImport
+    , lookupPathToId
+    , pathToId
+    , processDependencyInformation
+    , reachableModules
+    , transitiveDeps
+    , transitiveReverseDependencies
+    ) where
 
-  , PathIdMap
-  , emptyPathIdMap
-  , getPathId
-  , lookupPathToId
-  , insertImport
-  , pathToId
-  , idToPath
-  , reachableModules
-  , processDependencyInformation
-  , transitiveDeps
-  , transitiveReverseDependencies
-  , immediateReverseDependencies
-
-  , BootIdMap
-  , insertBootId
-  ) where
-
-import Control.DeepSeq
-import Data.Bifunctor
-import Data.Coerce
-import Data.List
-import Data.Tuple.Extra hiding (first, second)
-import Development.IDE.GHC.Orphans()
-import Data.Either
-import Data.Graph
-import Data.HashMap.Strict (HashMap)
-import qualified Data.HashMap.Strict as HMS
-import Data.List.NonEmpty (NonEmpty(..), nonEmpty)
-import qualified Data.List.NonEmpty as NonEmpty
-import Data.IntMap (IntMap)
-import qualified Data.IntMap.Strict as IntMap
-import qualified Data.IntMap.Lazy as IntMapLazy
-import Data.IntSet (IntSet)
-import qualified Data.IntSet as IntSet
-import Data.Maybe
-import Data.Set (Set)
-import qualified Data.Set as Set
-import GHC.Generics (Generic)
-
-import Development.IDE.Types.Diagnostics
-import Development.IDE.Types.Location
-import Development.IDE.Import.FindImports (ArtifactsLocation(..))
-
-import GHC
-import Module
+import           Control.DeepSeq
+import           Data.Bifunctor
+import           Data.Coerce
+import           Data.Either
+import           Data.Graph
+import           Data.HashMap.Strict                (HashMap)
+import qualified Data.HashMap.Strict                as HMS
+import           Data.IntMap                        (IntMap)
+import qualified Data.IntMap.Lazy                   as IntMapLazy
+import qualified Data.IntMap.Strict                 as IntMap
+import           Data.IntSet                        (IntSet)
+import qualified Data.IntSet                        as IntSet
+import           Data.List
+import           Data.List.NonEmpty                 (NonEmpty (..), nonEmpty)
+import qualified Data.List.NonEmpty                 as NonEmpty
+import           Data.Maybe
+import           Data.Set                           (Set)
+import qualified Data.Set                           as Set
+import           Data.Tuple.Extra                   hiding (first, second)
+import           Development.IDE.GHC.Orphans        ()
+import           Development.IDE.Import.FindImports (ArtifactsLocation (..))
+import           Development.IDE.Types.Diagnostics
+import           Development.IDE.Types.Location
+import           GHC
+import           GHC.Generics                       (Generic)
+import           Module
 
 -- | The imports for a given module.
 data ModuleImports = ModuleImports

--- a/src/Development/IDE/Import/FindImports.hs
+++ b/src/Development/IDE/Import/FindImports.hs
@@ -5,34 +5,31 @@
 #include "ghc-api-version.h"
 
 module Development.IDE.Import.FindImports
-  ( locateModule
-  , Import(..)
-  , ArtifactsLocation(..)
-  , modSummaryToArtifactsLocation
-  , isBootLocation
-  , mkImportDirs
-  ) where
+    ( ArtifactsLocation (..)
+    , Import (..)
+    , isBootLocation
+    , locateModule
+    , mkImportDirs
+    , modSummaryToArtifactsLocation
+    ) where
 
-import           Development.IDE.GHC.Error as ErrUtils
-import Development.IDE.GHC.Orphans()
-import Development.IDE.Types.Diagnostics
-import Development.IDE.Types.Location
-import Development.IDE.GHC.Compat
--- GHC imports
-import           FastString
-import qualified Module                      as M
-import           Packages
-import           Outputable                  (showSDoc, ppr, pprPanic)
-import           Finder
-import Control.DeepSeq
-
--- standard imports
+import           Control.DeepSeq
 import           Control.Monad.Extra
 import           Control.Monad.IO.Class
+import           Data.List                         (isSuffixOf)
+import           Data.Maybe
+import           Development.IDE.GHC.Compat
+import           Development.IDE.GHC.Error         as ErrUtils
+import           Development.IDE.GHC.Orphans       ()
+import           Development.IDE.Types.Diagnostics
+import           Development.IDE.Types.Location
+import           DriverPhases
+import           FastString
+import           Finder
+import qualified Module                            as M
+import           Outputable                        (ppr, pprPanic, showSDoc)
+import           Packages
 import           System.FilePath
-import DriverPhases
-import Data.Maybe
-import Data.List (isSuffixOf)
 
 data Import
   = FileImport !ArtifactsLocation

--- a/src/Development/IDE/LSP/HoverDefinition.hs
+++ b/src/Development/IDE/LSP/HoverDefinition.hs
@@ -4,26 +4,25 @@
 
 -- | Display information on hover.
 module Development.IDE.LSP.HoverDefinition
-    ( setHandlersHover
-    , setHandlersDefinition
-    , setHandlersTypeDefinition
+    ( setHandlersDefinition
     , setHandlersDocHighlight
-    -- * For haskell-language-server
-    , hover
+    , setHandlersHover
+    , setHandlersTypeDefinition
+      -- * For haskell-language-server
     , gotoDefinition
     , gotoTypeDefinition
+    , hover
     ) where
 
+import qualified Data.Text                      as T
 import           Development.IDE.Core.Rules
 import           Development.IDE.Core.Shake
 import           Development.IDE.LSP.Server
 import           Development.IDE.Types.Location
 import           Development.IDE.Types.Logger
-import qualified Language.Haskell.LSP.Core       as LSP
+import qualified Language.Haskell.LSP.Core      as LSP
 import           Language.Haskell.LSP.Messages
 import           Language.Haskell.LSP.Types
-
-import qualified Data.Text as T
 
 gotoDefinition :: IdeState -> TextDocumentPositionParams -> IO (Either ResponseError LocationResponseParams)
 hover          :: IdeState -> TextDocumentPositionParams -> IO (Either ResponseError (Maybe Hover))

--- a/src/Development/IDE/LSP/LanguageServer.hs
+++ b/src/Development/IDE/LSP/LanguageServer.hs
@@ -1,8 +1,8 @@
 -- Copyright (c) 2019 The DAML Authors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-{-# LANGUAGE ExistentialQuantification  #-}
-{-# LANGUAGE RankNTypes                 #-}
+{-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE RankNTypes                #-}
 
 -- WARNING: A copy of DA.Daml.LanguageServer, try to keep them in sync
 -- This version removes the daml: handling
@@ -10,34 +10,33 @@ module Development.IDE.LSP.LanguageServer
     ( runLanguageServer
     ) where
 
+import           Control.Concurrent.Async
+import           Control.Concurrent.Chan
+import           Control.Concurrent.Extra
+import           Control.Concurrent.STM
+import           Control.Exception.Safe
+import           Control.Monad.Extra
+import           Data.Default
+import           Data.Maybe
+import qualified Data.Set                                as Set
+import qualified Data.Text                               as T
+import           Development.IDE.Core.FileStore
+import           Development.IDE.Core.IdeConfiguration
+import           Development.IDE.Core.Shake
+import qualified Development.IDE.GHC.Util                as Ghcide
+import           Development.IDE.LSP.HoverDefinition
+import           Development.IDE.LSP.Notifications
+import           Development.IDE.LSP.Outline
+import           Development.IDE.LSP.Server
+import           Development.IDE.Types.Logger
+import           GHC.IO.Handle                           (hDuplicate)
+import qualified Language.Haskell.LSP.Control            as LSP
+import           Language.Haskell.LSP.Core               (LspFuncs (..))
+import qualified Language.Haskell.LSP.Core               as LSP
+import           Language.Haskell.LSP.Messages
 import           Language.Haskell.LSP.Types
 import           Language.Haskell.LSP.Types.Capabilities
-import           Development.IDE.LSP.Server
-import qualified Development.IDE.GHC.Util as Ghcide
-import qualified Language.Haskell.LSP.Control as LSP
-import qualified Language.Haskell.LSP.Core as LSP
-import Control.Concurrent.Chan
-import Control.Concurrent.Extra
-import Control.Concurrent.Async
-import Control.Concurrent.STM
-import Control.Exception.Safe
-import Data.Default
-import Data.Maybe
-import qualified Data.Set as Set
-import qualified Data.Text as T
-import GHC.IO.Handle (hDuplicate)
-import System.IO
-import Control.Monad.Extra
-
-import Development.IDE.Core.IdeConfiguration
-import Development.IDE.Core.Shake
-import Development.IDE.LSP.HoverDefinition
-import Development.IDE.LSP.Notifications
-import Development.IDE.LSP.Outline
-import Development.IDE.Types.Logger
-import Development.IDE.Core.FileStore
-import Language.Haskell.LSP.Core (LspFuncs(..))
-import Language.Haskell.LSP.Messages
+import           System.IO
 
 runLanguageServer
     :: forall config. (Show config)

--- a/src/Development/IDE/LSP/Notifications.hs
+++ b/src/Development/IDE/LSP/Notifications.hs
@@ -8,31 +8,28 @@ module Development.IDE.LSP.Notifications
     ( setHandlersNotifications
     ) where
 
-import           Development.IDE.LSP.Server
-import qualified Language.Haskell.LSP.Core        as LSP
-import           Language.Haskell.LSP.Types
-import qualified Language.Haskell.LSP.Types       as LSP
-import qualified Language.Haskell.LSP.Messages    as LSP
-import qualified Language.Haskell.LSP.Types.Capabilities as LSP
-
+import           Control.Monad.Extra
+import qualified Data.Aeson                              as A
+import           Data.Foldable                           as F
+import qualified Data.HashMap.Strict                     as M
+import qualified Data.HashSet                            as S
+import           Data.Maybe
+import qualified Data.Text                               as Text
+import           Development.IDE.Core.FileExists         (modifyFileExists, watchedGlobs)
+import           Development.IDE.Core.FileStore          (setFileModified, setSomethingModified, typecheckParents)
 import           Development.IDE.Core.IdeConfiguration
+import           Development.IDE.Core.OfInterest
 import           Development.IDE.Core.Service
 import           Development.IDE.Core.Shake
+import           Development.IDE.LSP.Server
 import           Development.IDE.Types.Location
 import           Development.IDE.Types.Logger
 import           Development.IDE.Types.Options
-
-import           Control.Monad.Extra
-import qualified Data.Aeson                       as A
-import           Data.Foldable                    as F
-import           Data.Maybe
-import qualified Data.HashMap.Strict              as M
-import qualified Data.HashSet                     as S
-import qualified Data.Text                        as Text
-
-import           Development.IDE.Core.FileStore   (setSomethingModified, setFileModified, typecheckParents)
-import           Development.IDE.Core.FileExists  (modifyFileExists, watchedGlobs)
-import           Development.IDE.Core.OfInterest
+import qualified Language.Haskell.LSP.Core               as LSP
+import qualified Language.Haskell.LSP.Messages           as LSP
+import           Language.Haskell.LSP.Types
+import qualified Language.Haskell.LSP.Types              as LSP
+import qualified Language.Haskell.LSP.Types.Capabilities as LSP
 
 
 whenUriFile :: Uri -> (NormalizedFilePath -> IO ()) -> IO ()

--- a/src/Development/IDE/LSP/Protocol.hs
+++ b/src/Development/IDE/LSP/Protocol.hs
@@ -6,10 +6,10 @@ module Development.IDE.LSP.Protocol
     ( pattern EventFileDiagnostics
     ) where
 
-import Development.IDE.Types.Diagnostics
-import Development.IDE.Types.Location
-import Language.Haskell.LSP.Messages
-import Language.Haskell.LSP.Types
+import           Development.IDE.Types.Diagnostics
+import           Development.IDE.Types.Location
+import           Language.Haskell.LSP.Messages
+import           Language.Haskell.LSP.Types
 
 ----------------------------------------------------------------------------------------------------
 -- Pretty printing

--- a/src/Development/IDE/LSP/Server.hs
+++ b/src/Development/IDE/LSP/Server.hs
@@ -2,19 +2,18 @@
 -- SPDX-License-Identifier: Apache-2.0
 
 {-# LANGUAGE DuplicateRecordFields #-}
-{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE RankNTypes            #-}
 module Development.IDE.LSP.Server
-  ( WithMessage(..)
-  , PartialHandlers(..)
-  ) where
+    ( PartialHandlers (..)
+    , WithMessage (..)
+    ) where
 
 
-import Data.Default
-
-import           Language.Haskell.LSP.Types
-import qualified Language.Haskell.LSP.Core as LSP
+import           Data.Default
+import           Development.IDE.Core.Service
+import qualified Language.Haskell.LSP.Core     as LSP
 import qualified Language.Haskell.LSP.Messages as LSP
-import Development.IDE.Core.Service
+import           Language.Haskell.LSP.Types
 
 data WithMessage c = WithMessage
     {withResponse :: forall m req resp . (Show m, Show req) =>

--- a/src/Development/IDE/Plugin.hs
+++ b/src/Development/IDE/Plugin.hs
@@ -1,20 +1,25 @@
 
-module Development.IDE.Plugin(Plugin(..), codeActionPlugin, codeActionPluginWithRules,makeLspCommandId,getPid) where
+module Development.IDE.Plugin
+    ( Plugin (..)
+    , codeActionPlugin
+    , codeActionPluginWithRules
+    , getPid
+    , makeLspCommandId
+    ) where
 
-import Data.Default
-import qualified Data.Text as T
-import Development.Shake
-import Development.IDE.LSP.Server
-
+import           Data.Default
+import qualified Data.Text                     as T
+import           Development.IDE.Compat
+import           Development.IDE.Core.Rules
+import           Development.IDE.LSP.Server
+import           Development.Shake
+import qualified Language.Haskell.LSP.Core     as LSP
+import           Language.Haskell.LSP.Messages
 import           Language.Haskell.LSP.Types
-import Development.IDE.Compat
-import Development.IDE.Core.Rules
-import qualified Language.Haskell.LSP.Core as LSP
-import Language.Haskell.LSP.Messages
 
 
 data Plugin c = Plugin
-    {pluginRules :: Rules ()
+    {pluginRules   :: Rules ()
     ,pluginHandler :: PartialHandlers c
     }
 

--- a/src/Development/IDE/Plugin/CodeAction/RuleTypes.hs
+++ b/src/Development/IDE/Plugin/CodeAction/RuleTypes.hs
@@ -1,17 +1,17 @@
 {-# LANGUAGE TypeFamilies #-}
 module Development.IDE.Plugin.CodeAction.RuleTypes
-    (PackageExports(..)
-    ,IdentInfo(..)
+    ( IdentInfo (..)
+    , PackageExports (..)
     ) where
 
-import Data.Hashable (Hashable)
-import Control.DeepSeq (NFData)
-import Data.Binary (Binary)
-import Development.IDE.GHC.Util
-import Development.IDE.Types.Exports
-import Development.Shake (RuleResult)
-import Data.Typeable (Typeable)
-import GHC.Generics (Generic)
+import           Control.DeepSeq               (NFData)
+import           Data.Binary                   (Binary)
+import           Data.Hashable                 (Hashable)
+import           Data.Typeable                 (Typeable)
+import           Development.IDE.GHC.Util
+import           Development.IDE.Types.Exports
+import           Development.Shake             (RuleResult)
+import           GHC.Generics                  (Generic)
 
 -- Rule type for caching Package Exports
 type instance RuleResult PackageExports = ExportsMap

--- a/src/Development/IDE/Plugin/Completions.hs
+++ b/src/Development/IDE/Plugin/Completions.hs
@@ -3,40 +3,38 @@
 #include "ghc-api-version.h"
 
 module Development.IDE.Plugin.Completions
-    (
-      plugin
-    , getCompletionsLSP
+    ( getCompletionsLSP
+    , plugin
     ) where
 
-import Language.Haskell.LSP.Messages
-import Language.Haskell.LSP.Types
-import qualified Language.Haskell.LSP.Core as LSP
-import qualified Language.Haskell.LSP.VFS as VFS
-import Language.Haskell.LSP.Types.Capabilities
-import Development.Shake.Classes
-import Development.Shake
-import GHC.Generics
-
-import Development.IDE.Plugin
-import Development.IDE.Core.Service
-import Development.IDE.Core.PositionMapping
-import Development.IDE.Plugin.Completions.Logic
-import Development.IDE.Types.Location
-import Development.IDE.Types.Options
-import Development.IDE.Core.Compile
-import Development.IDE.Core.RuleTypes
-import Development.IDE.Core.Shake
-import Development.IDE.GHC.Compat (hsmodExports, ParsedModule(..), ModSummary (ms_hspp_buf))
-
-import Development.IDE.GHC.Util
-import Development.IDE.LSP.Server
-import Control.Monad.Trans.Except (runExceptT)
-import HscTypes (HscEnv(hsc_dflags))
-import Data.Maybe
-import Data.Functor ((<&>))
+import           Control.Monad.Trans.Except                   (runExceptT)
+import           Data.Functor                                 ((<&>))
+import           Data.Maybe
+import           Development.IDE.Core.Compile
+import           Development.IDE.Core.PositionMapping
+import           Development.IDE.Core.RuleTypes
+import           Development.IDE.Core.Service
+import           Development.IDE.Core.Shake
+import           Development.IDE.GHC.Compat                   (ModSummary (ms_hspp_buf), ParsedModule (..),
+                                                               hsmodExports)
+import           Development.IDE.GHC.Util
+import           Development.IDE.LSP.Server
+import           Development.IDE.Plugin
+import           Development.IDE.Plugin.Completions.Logic
+import           Development.IDE.Types.Location
+import           Development.IDE.Types.Options
+import           Development.Shake
+import           Development.Shake.Classes
+import           GHC.Generics
+import           HscTypes                                     (HscEnv (hsc_dflags))
+import qualified Language.Haskell.LSP.Core                    as LSP
+import           Language.Haskell.LSP.Messages
+import           Language.Haskell.LSP.Types
+import           Language.Haskell.LSP.Types.Capabilities
+import qualified Language.Haskell.LSP.VFS                     as VFS
 
 #if defined(GHC_LIB)
-import Development.IDE.Import.DependencyInformation
+import           Development.IDE.Import.DependencyInformation
 #endif
 
 plugin :: Plugin c

--- a/src/Development/IDE/Plugin/Completions/Logic.hs
+++ b/src/Development/IDE/Plugin/Completions/Logic.hs
@@ -1,53 +1,51 @@
 {-# LANGUAGE CPP #-}
 #include "ghc-api-version.h"
 -- Mostly taken from "haskell-ide-engine"
-module Development.IDE.Plugin.Completions.Logic (
-  CachedCompletions
-, cacheDataProducer
-, localCompletionsForParsedModule
-, WithSnippets(..)
-, getCompletions
-) where
+module Development.IDE.Plugin.Completions.Logic
+    ( CachedCompletions
+    , WithSnippets (..)
+    , cacheDataProducer
+    , getCompletions
+    , localCompletionsForParsedModule
+    ) where
 
-import Control.Applicative
-import Data.Char (isUpper)
-import Data.Generics
-import Data.List.Extra as List hiding (stripPrefix)
-import qualified Data.Map  as Map
-import Data.Maybe (fromMaybe, mapMaybe)
-import qualified Data.Text as T
-import qualified Text.Fuzzy as Fuzzy
-
-import HscTypes
-import Name
-import RdrName
-import TcRnTypes
-import Type
-import Var
-import Packages
-import DynFlags
+import           Control.Applicative
+import           Data.Char                                (isUpper)
+import           Data.Generics
+import           Data.List.Extra                          as List hiding (stripPrefix)
+import qualified Data.Map                                 as Map
+import           Data.Maybe                               (fromMaybe, mapMaybe)
+import qualified Data.Set                                 as Set
+import qualified Data.Text                                as T
+import           Development.IDE.Core.Compile
+import           Development.IDE.Core.PositionMapping
+import           Development.IDE.GHC.Compat               as GHC
+import           Development.IDE.GHC.Error
+import           Development.IDE.GHC.Util
+import           Development.IDE.Plugin.Completions.Types
+import           Development.IDE.Spans.Common
+import           Development.IDE.Spans.Documentation
+import           Development.IDE.Spans.LocalBindings
+import           Development.IDE.Types.Options
+import           DynFlags
+import           HscTypes
+import           Language.Haskell.LSP.Types
+import           Language.Haskell.LSP.Types.Capabilities
+import qualified Language.Haskell.LSP.VFS                 as VFS
+import           Name
+import           Outputable                               (Outputable)
+import           Packages
+import           RdrName
+import           TcRnTypes
+import qualified Text.Fuzzy                               as Fuzzy
+import           Type
+import           Var
 #if MIN_GHC_API_VERSION(8,10,0)
-import Predicate (isDictTy)
-import GHC.Platform
-import Pair
-import Coercion
+import           Coercion
+import           GHC.Platform
+import           Pair
+import           Predicate                                (isDictTy)
 #endif
-
-import Language.Haskell.LSP.Types
-import Language.Haskell.LSP.Types.Capabilities
-import qualified Language.Haskell.LSP.VFS as VFS
-import Development.IDE.Core.Compile
-import Development.IDE.Core.PositionMapping
-import Development.IDE.Plugin.Completions.Types
-import Development.IDE.Spans.Documentation
-import Development.IDE.Spans.LocalBindings
-import Development.IDE.GHC.Compat as GHC
-import Development.IDE.GHC.Error
-import Development.IDE.Types.Options
-import Development.IDE.Spans.Common
-import Development.IDE.GHC.Util
-import Outputable (Outputable)
-import qualified Data.Set as Set
 
 -- From haskell-ide-engine/hie-plugin-api/Haskell/Ide/Engine/Context.hs
 

--- a/src/Development/IDE/Plugin/Completions/Types.hs
+++ b/src/Development/IDE/Plugin/Completions/Types.hs
@@ -1,14 +1,13 @@
-module Development.IDE.Plugin.Completions.Types (
-  module Development.IDE.Plugin.Completions.Types
-) where
+module Development.IDE.Plugin.Completions.Types
+    ( module Development.IDE.Plugin.Completions.Types
+    ) where
 
 import           Control.DeepSeq
-import qualified Data.Map  as Map
-import qualified Data.Text as T
-import SrcLoc
-
-import Development.IDE.Spans.Common
-import Language.Haskell.LSP.Types (CompletionItemKind)
+import qualified Data.Map                     as Map
+import qualified Data.Text                    as T
+import           Development.IDE.Spans.Common
+import           Language.Haskell.LSP.Types   (CompletionItemKind)
+import           SrcLoc
 
 -- From haskell-ide-engine/src/Haskell/Ide/Engine/LSP/Completions.hs
 

--- a/src/Development/IDE/Plugin/Test.hs
+++ b/src/Development/IDE/Plugin/Test.hs
@@ -1,26 +1,29 @@
-{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveAnyClass     #-}
 {-# LANGUAGE DerivingStrategies #-}
 -- | A plugin that adds custom messages for use in tests
-module Development.IDE.Plugin.Test (TestRequest(..), plugin) where
+module Development.IDE.Plugin.Test
+    ( TestRequest (..)
+    , plugin
+    ) where
 
-import Control.Monad.STM
-import Data.Aeson
-import Data.Aeson.Types
-import Development.IDE.Core.Service
-import Development.IDE.Core.Shake
-import Development.IDE.GHC.Compat
-import Development.IDE.GHC.Util (HscEnvEq(hscEnv))
-import Development.IDE.LSP.Server
-import Development.IDE.Plugin
-import Development.IDE.Types.Action
-import GHC.Generics (Generic)
-import GhcPlugins (HscEnv(hsc_dflags))
-import Language.Haskell.LSP.Core
-import Language.Haskell.LSP.Messages
-import Language.Haskell.LSP.Types
-import System.Time.Extra
-import Development.IDE.Core.RuleTypes
-import Control.Monad
+import           Control.Monad
+import           Control.Monad.STM
+import           Data.Aeson
+import           Data.Aeson.Types
+import           Development.IDE.Core.RuleTypes
+import           Development.IDE.Core.Service
+import           Development.IDE.Core.Shake
+import           Development.IDE.GHC.Compat
+import           Development.IDE.GHC.Util       (HscEnvEq (hscEnv))
+import           Development.IDE.LSP.Server
+import           Development.IDE.Plugin
+import           Development.IDE.Types.Action
+import           GHC.Generics                   (Generic)
+import           GhcPlugins                     (HscEnv (hsc_dflags))
+import           Language.Haskell.LSP.Core
+import           Language.Haskell.LSP.Messages
+import           Language.Haskell.LSP.Types
+import           System.Time.Extra
 
 data TestRequest
     = BlockSeconds Seconds           -- ^ :: Null

--- a/src/Development/IDE/Spans/AtPoint.hs
+++ b/src/Development/IDE/Spans/AtPoint.hs
@@ -3,48 +3,41 @@
 
 -- | Gives information about symbols at a given point in DAML files.
 -- These are all pure functions that should execute quickly.
-module Development.IDE.Spans.AtPoint (
-    atPoint
-  , gotoDefinition
-  , gotoTypeDefinition
-  , documentHighlight
-  , pointCommand
-  ) where
+module Development.IDE.Spans.AtPoint
+    ( atPoint
+    , documentHighlight
+    , gotoDefinition
+    , gotoTypeDefinition
+    , pointCommand
+    ) where
 
-import           Development.IDE.GHC.Error
-import Development.IDE.GHC.Orphans()
-import Development.IDE.Types.Location
-import           Language.Haskell.LSP.Types
-
--- DAML compiler and infrastructure
-import Development.IDE.GHC.Compat
-import Development.IDE.Types.Options
-import Development.IDE.Spans.Common
-import Development.IDE.Core.RuleTypes
-
--- GHC API imports
-import FastString
-import Name
-import Outputable hiding ((<>))
-import SrcLoc
-import TyCoRep
-import TyCon
-import qualified Var
-import NameEnv
-
-import Control.Applicative
-import Control.Monad.Extra
-import Control.Monad.Trans.Maybe
-import Control.Monad.Trans.Class
-import Control.Monad.IO.Class
-import           Data.Maybe
+import           Control.Applicative
+import           Control.Monad.Extra
+import           Control.Monad.IO.Class
+import           Control.Monad.Trans.Class
+import           Control.Monad.Trans.Maybe
+import           Data.Either
 import           Data.List
-import qualified Data.Text as T
-import qualified Data.Map as M
-
-
-import Data.Either
-import Data.List.Extra (dropEnd1)
+import           Data.List.Extra                (dropEnd1)
+import qualified Data.Map                       as M
+import           Data.Maybe
+import qualified Data.Text                      as T
+import           Development.IDE.Core.RuleTypes
+import           Development.IDE.GHC.Compat
+import           Development.IDE.GHC.Error
+import           Development.IDE.GHC.Orphans    ()
+import           Development.IDE.Spans.Common
+import           Development.IDE.Types.Location
+import           Development.IDE.Types.Options
+import           FastString
+import           Language.Haskell.LSP.Types
+import           Name
+import           NameEnv
+import           Outputable                     hiding ((<>))
+import           SrcLoc
+import           TyCoRep
+import           TyCon
+import qualified Var
 
 documentHighlight
   :: Monad m

--- a/src/Development/IDE/Spans/Common.hs
+++ b/src/Development/IDE/Spans/Common.hs
@@ -1,39 +1,37 @@
-{-# LANGUAGE CPP #-}
-{-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE CPP                #-}
+{-# LANGUAGE DeriveAnyClass     #-}
+{-# LANGUAGE DerivingStrategies #-}
 #include "ghc-api-version.h"
 
-module Development.IDE.Spans.Common (
-  showGhc
-, showName
-, safeTyThingId
-, safeTyThingType
-, SpanDoc(..)
-, SpanDocUris(..)
-, emptySpanDoc
-, spanDocToMarkdown
-, spanDocToMarkdownForTest
-, DocMap
-, KindMap
-) where
+module Development.IDE.Spans.Common
+    ( DocMap
+    , KindMap
+    , SpanDoc (..)
+    , SpanDocUris (..)
+    , emptySpanDoc
+    , safeTyThingId
+    , safeTyThingType
+    , showGhc
+    , showName
+    , spanDocToMarkdown
+    , spanDocToMarkdownForTest
+    ) where
 
-import Data.Maybe
-import qualified Data.Text as T
-import Data.List.Extra
-import Control.DeepSeq
-import GHC.Generics
-
-import GHC
-import Outputable hiding ((<>))
-import DynFlags
-import ConLike
-import DataCon
-import Var
-import NameEnv
-
+import           ConLike
+import           Control.DeepSeq
+import           Data.List.Extra
+import           Data.Maybe
+import qualified Data.Text                    as T
+import           DataCon
+import           Development.IDE.GHC.Orphans  ()
 import qualified Documentation.Haddock.Parser as H
-import qualified Documentation.Haddock.Types as H
-import Development.IDE.GHC.Orphans ()
+import qualified Documentation.Haddock.Types  as H
+import           DynFlags
+import           GHC
+import           GHC.Generics
+import           NameEnv
+import           Outputable                   hiding ((<>))
+import           Var
 
 type DocMap = NameEnv SpanDoc
 type KindMap = NameEnv TyThing

--- a/src/Development/IDE/Spans/Documentation.hs
+++ b/src/Development/IDE/Spans/Documentation.hs
@@ -2,43 +2,42 @@
 -- Copyright (c) 2019 The DAML Authors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-{-# LANGUAGE CPP #-}
+{-# LANGUAGE CPP        #-}
 #include "ghc-api-version.h"
 
-module Development.IDE.Spans.Documentation (
-    getDocumentation
-  , getDocumentationTryGhc
-  , getDocumentationsTryGhc
-  , DocMap
-  , mkDocMap
-  ) where
+module Development.IDE.Spans.Documentation
+    ( DocMap
+    , getDocumentation
+    , getDocumentationTryGhc
+    , getDocumentationsTryGhc
+    , mkDocMap
+    ) where
 
 import           Control.Monad
-import           Control.Monad.Extra (findM)
+import           Control.Monad.Extra            (findM)
 import           Data.Either
 import           Data.Foldable
 import           Data.List.Extra
-import qualified Data.Map as M
-import qualified Data.Set as S
+import qualified Data.Map                       as M
 import           Data.Maybe
-import qualified Data.Text as T
+import qualified Data.Set                       as S
+import qualified Data.Text                      as T
 import           Development.IDE.Core.Compile
+import           Development.IDE.Core.RuleTypes
 import           Development.IDE.GHC.Compat
 import           Development.IDE.GHC.Error
 import           Development.IDE.Spans.Common
-import           Development.IDE.Core.RuleTypes
+import           ExtractDocs
+import           FastString
+import           GhcMonad
+import           Language.Haskell.LSP.Types     (filePathToUri, getUri)
+import           Name
+import           NameEnv
+import           Packages
+import           SrcLoc                         (RealLocated)
 import           System.Directory
 import           System.FilePath
-
-import           FastString
-import           SrcLoc (RealLocated)
-import           GhcMonad
-import           Packages
-import           Name
-import           Language.Haskell.LSP.Types (getUri, filePathToUri)
 import           TcRnTypes
-import           ExtractDocs
-import           NameEnv
 
 mkDocMap
   :: GhcMonad m
@@ -87,7 +86,7 @@ getDocumentationsTryGhc mod sources names = do
 
     mkSpanDocText name =
       pure (SpanDocText (getDocumentation sources name)) <*> getUris name
-   
+
     -- Get the uris to the documentation and source html pages if they exist
     getUris name = do
       df <- getSessionDynFlags
@@ -220,6 +219,6 @@ lookupHtmlForModule mkDocPath df m = do
 
 lookupHtmls :: DynFlags -> UnitId -> Maybe [FilePath]
 lookupHtmls df ui =
-  -- use haddockInterfaces instead of haddockHTMLs: GHC treats haddockHTMLs as URL not path 
+  -- use haddockInterfaces instead of haddockHTMLs: GHC treats haddockHTMLs as URL not path
   -- and therefore doesn't expand $topdir on Windows
   map takeDirectory . haddockInterfaces <$> lookupPackage df ui

--- a/src/Development/IDE/Spans/LocalBindings.hs
+++ b/src/Development/IDE/Spans/LocalBindings.hs
@@ -1,23 +1,24 @@
-{-# LANGUAGE DerivingStrategies         #-}
+{-# LANGUAGE DerivingStrategies #-}
 
 module Development.IDE.Spans.LocalBindings
-  ( Bindings
-  , getLocalScope
-  , getFuzzyScope
-  , bindings
-  ) where
+    ( Bindings
+    , bindings
+    , getFuzzyScope
+    , getLocalScope
+    ) where
 
 import           Control.DeepSeq
-import           Data.IntervalMap.FingerTree (IntervalMap, Interval (..))
-import qualified Data.IntervalMap.FingerTree as IM
-import qualified Data.Map as M
-import qualified Data.Set as S
-import qualified Data.List as L
-import           Development.IDE.GHC.Compat (RefMap, identType, identInfo, getScopeFromContext, Scope(..), Name, Type)
-import           Development.IDE.Types.Location
+import           Data.IntervalMap.FingerTree    (Interval (..), IntervalMap)
+import qualified Data.IntervalMap.FingerTree    as IM
+import qualified Data.List                      as L
+import qualified Data.Map                       as M
+import qualified Data.Set                       as S
+import           Development.IDE.GHC.Compat     (Name, RefMap, Scope (..), Type, getScopeFromContext, identInfo,
+                                                 identType)
 import           Development.IDE.GHC.Error
-import           SrcLoc
+import           Development.IDE.Types.Location
 import           NameEnv
+import           SrcLoc
 
 ------------------------------------------------------------------------------
 -- | Turn a 'RealSrcSpan' into an 'Interval'.

--- a/src/Development/IDE/Types/Action.hs
+++ b/src/Development/IDE/Types/Action.hs
@@ -11,9 +11,9 @@ module Development.IDE.Types.Action
 where
 
 import           Control.Concurrent.STM
-import           Data.Hashable                (Hashable (..))
 import           Data.HashSet                 (HashSet)
 import qualified Data.HashSet                 as Set
+import           Data.Hashable                (Hashable (..))
 import           Data.Unique                  (Unique)
 import           Development.IDE.Types.Logger
 import           Development.Shake            (Action)

--- a/src/Development/IDE/Types/Diagnostics.hs
+++ b/src/Development/IDE/Types/Diagnostics.hs
@@ -2,35 +2,32 @@
 -- SPDX-License-Identifier: Apache-2.0
 
 
-module Development.IDE.Types.Diagnostics (
-  LSP.Diagnostic(..),
-  ShowDiagnostic(..),
-  FileDiagnostic,
-  IdeResult,
-  LSP.DiagnosticSeverity(..),
-  DiagnosticStore,
-  List(..),
-  ideErrorText,
-  ideErrorWithSource,
-  showDiagnostics,
-  showDiagnosticsColored,
-  ) where
+module Development.IDE.Types.Diagnostics
+    ( DiagnosticStore
+    , FileDiagnostic
+    , IdeResult
+    , LSP.Diagnostic (..)
+    , LSP.DiagnosticSeverity (..)
+    , List (..)
+    , ShowDiagnostic (..)
+    , ideErrorText
+    , ideErrorWithSource
+    , showDiagnostics
+    , showDiagnosticsColored
+    ) where
 
-import Control.DeepSeq
-import Data.Maybe as Maybe
-import qualified Data.Text as T
-import Data.Text.Prettyprint.Doc
-import Language.Haskell.LSP.Types as LSP (DiagnosticSource,
-    DiagnosticSeverity(..)
-  , Diagnostic(..)
-  , List(..)
-  )
-import Language.Haskell.LSP.Diagnostics
-import Data.Text.Prettyprint.Doc.Render.Text
+import           Control.DeepSeq
+import           Data.Maybe                                as Maybe
+import qualified Data.Text                                 as T
+import           Data.Text.Prettyprint.Doc
+import           Data.Text.Prettyprint.Doc.Render.Terminal (Color (..), color)
 import qualified Data.Text.Prettyprint.Doc.Render.Terminal as Terminal
-import Data.Text.Prettyprint.Doc.Render.Terminal (Color(..), color)
+import           Data.Text.Prettyprint.Doc.Render.Text
+import           Language.Haskell.LSP.Diagnostics
+import           Language.Haskell.LSP.Types                as LSP (Diagnostic (..), DiagnosticSeverity (..),
+                                                                   DiagnosticSource, List (..))
 
-import Development.IDE.Types.Location
+import           Development.IDE.Types.Location
 
 
 -- | The result of an IDE operation. Warnings and errors are in the Diagnostic,
@@ -114,10 +111,10 @@ prettyDiagnostic (fp, sh, LSP.Diagnostic{..}) =
         , slabel_ "Severity:" $ pretty $ show sev
         , slabel_ "Message: "
             $ case sev of
-              LSP.DsError -> annotate $ color Red
+              LSP.DsError   -> annotate $ color Red
               LSP.DsWarning -> annotate $ color Yellow
-              LSP.DsInfo -> annotate $ color Blue
-              LSP.DsHint -> annotate $ color Magenta
+              LSP.DsInfo    -> annotate $ color Blue
+              LSP.DsHint    -> annotate $ color Magenta
             $ stringParagraphs _message
         ]
     where

--- a/src/Development/IDE/Types/Exports.hs
+++ b/src/Development/IDE/Types/Exports.hs
@@ -1,30 +1,29 @@
-{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveAnyClass     #-}
 {-# LANGUAGE DerivingStrategies #-}
 module Development.IDE.Types.Exports
-(
-    IdentInfo(..),
-    ExportsMap(..),
-    createExportsMap,
-    createExportsMapMg,
-    createExportsMapTc
-) where
+    ( ExportsMap (..)
+    , IdentInfo (..)
+    , createExportsMap
+    , createExportsMapMg
+    , createExportsMapTc
+    ) where
 
-import Avail (AvailInfo(..))
-import Control.DeepSeq (NFData)
-import Data.Text (pack, Text)
-import Development.IDE.GHC.Compat
-import Development.IDE.GHC.Util
-import Data.HashMap.Strict (HashMap)
-import GHC.Generics (Generic)
-import Name
-import FieldLabel (flSelector)
-import qualified Data.HashMap.Strict as Map
-import GhcPlugins (IfaceExport, ModGuts(..))
-import Data.HashSet (HashSet)
-import qualified Data.HashSet as Set
-import Data.Bifunctor (Bifunctor(second))
-import Data.Hashable (Hashable)
-import TcRnTypes(TcGblEnv(..))
+import           Avail                      (AvailInfo (..))
+import           Control.DeepSeq            (NFData)
+import           Data.Bifunctor             (Bifunctor (second))
+import           Data.HashMap.Strict        (HashMap)
+import qualified Data.HashMap.Strict        as Map
+import           Data.HashSet               (HashSet)
+import qualified Data.HashSet               as Set
+import           Data.Hashable              (Hashable)
+import           Data.Text                  (Text, pack)
+import           Development.IDE.GHC.Compat
+import           Development.IDE.GHC.Util
+import           FieldLabel                 (flSelector)
+import           GHC.Generics               (Generic)
+import           GhcPlugins                 (IfaceExport, ModGuts (..))
+import           Name
+import           TcRnTypes                  (TcGblEnv (..))
 
 newtype ExportsMap = ExportsMap
     {getExportsMap :: HashMap IdentifierText (HashSet (IdentInfo,ModuleNameText))}
@@ -37,9 +36,9 @@ type IdentifierText = Text
 type ModuleNameText = Text
 
 data IdentInfo = IdentInfo
-    { name :: !Text
-    , rendered :: Text
-    , parent :: !(Maybe Text)
+    { name      :: !Text
+    , rendered  :: Text
+    , parent    :: !(Maybe Text)
     , isDatacon :: !Bool
     }
     deriving (Eq, Generic, Show)

--- a/src/Development/IDE/Types/Location.hs
+++ b/src/Development/IDE/Types/Location.hs
@@ -4,37 +4,37 @@
 
 -- | Types and functions for working with source code locations.
 module Development.IDE.Types.Location
-    ( Location(..)
-    , noFilePath
-    , noRange
-    , Position(..)
-    , showPosition
-    , Range(..)
-    , LSP.Uri(..)
+    ( LSP.NormalizedFilePath
     , LSP.NormalizedUri
-    , LSP.toNormalizedUri
+    , LSP.Uri (..)
+    , LSP.fromNormalizedFilePath
     , LSP.fromNormalizedUri
-    , LSP.NormalizedFilePath
-    , fromUri
+    , LSP.toNormalizedUri
+    , Location (..)
+    , Position (..)
+    , Range (..)
     , emptyFilePath
     , emptyPathUri
-    , toNormalizedFilePath'
-    , LSP.fromNormalizedFilePath
     , filePathToUri'
-    , uriToFilePath'
+    , fromUri
+    , noFilePath
+    , noRange
     , readSrcSpan
+    , showPosition
+    , toNormalizedFilePath'
+    , uriToFilePath'
     ) where
 
-import Control.Applicative
-import Language.Haskell.LSP.Types (Location(..), Range(..), Position(..))
-import Control.Monad
-import Data.Hashable (Hashable(hash))
-import Data.String
-import FastString
-import qualified Language.Haskell.LSP.Types as LSP
-import SrcLoc as GHC
-import Text.ParserCombinators.ReadP as ReadP
-import Data.Maybe (fromMaybe)
+import           Control.Applicative
+import           Control.Monad
+import           Data.Hashable                (Hashable (hash))
+import           Data.Maybe                   (fromMaybe)
+import           Data.String
+import           FastString
+import           Language.Haskell.LSP.Types   (Location (..), Position (..), Range (..))
+import qualified Language.Haskell.LSP.Types   as LSP
+import           SrcLoc                       as GHC
+import           Text.ParserCombinators.ReadP as ReadP
 
 toNormalizedFilePath' :: FilePath -> LSP.NormalizedFilePath
 -- We want to keep empty paths instead of normalising them to "."

--- a/src/Development/IDE/Types/Logger.hs
+++ b/src/Development/IDE/Types/Logger.hs
@@ -6,11 +6,15 @@
 -- concrete choice of logging framework so users can plug in whatever
 -- framework they want to.
 module Development.IDE.Types.Logger
-  ( Priority(..)
-  , Logger(..)
-  , logError, logWarning, logInfo, logDebug, logTelemetry
-  , noLogging
-  ) where
+    ( Logger (..)
+    , Priority (..)
+    , logDebug
+    , logError
+    , logInfo
+    , logTelemetry
+    , logWarning
+    , noLogging
+    ) where
 
 import qualified Data.Text as T
 

--- a/src/Development/IDE/Types/Options.hs
+++ b/src/Development/IDE/Types/Options.hs
@@ -1,42 +1,42 @@
 -- Copyright (c) 2019 The DAML Authors. All rights reserved.
 -- SPDX-License-Identifier: Apache-2.0
 
-{-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveAnyClass     #-}
+{-# LANGUAGE DeriveGeneric      #-}
 {-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE RankNTypes         #-}
 
 {- HLINT ignore "Avoid restricted extensions" -}
 
 -- | Options
 module Development.IDE.Types.Options
-  ( IdeOptions(..)
-  , IdePreprocessedSource(..)
-  , IdeReportProgress(..)
-  , IdeDefer(..)
-  , IdeTesting(..)
-  , clientSupportsProgress
-  , IdePkgLocationOptions(..)
-  , defaultIdeOptions
-  , IdeResult
-  , IdeGhcSession(..)
-  , LspConfig(..)
-  , defaultLspConfig
-  , CheckProject(..)
-  , CheckParents(..)
-  , OptHaddockParse(..)
-  ) where
+    ( CheckParents (..)
+    , CheckProject (..)
+    , IdeDefer (..)
+    , IdeGhcSession (..)
+    , IdeOptions (..)
+    , IdePkgLocationOptions (..)
+    , IdePreprocessedSource (..)
+    , IdeReportProgress (..)
+    , IdeResult
+    , IdeTesting (..)
+    , LspConfig (..)
+    , OptHaddockParse (..)
+    , clientSupportsProgress
+    , defaultIdeOptions
+    , defaultLspConfig
+    ) where
 
-import Development.Shake
-import Development.IDE.GHC.Util
-import           GHC hiding (parseModule, typecheckModule)
-import           GhcPlugins                     as GHC hiding (fst3, (<>))
+import           Control.DeepSeq                         (NFData (..))
+import           Data.Aeson
+import qualified Data.Text                               as T
+import           Development.IDE.GHC.Util
+import           Development.IDE.Types.Diagnostics
+import           Development.Shake
+import           GHC                                     hiding (parseModule, typecheckModule)
+import           GHC.Generics
+import           GhcPlugins                              as GHC hiding (fst3, (<>))
 import qualified Language.Haskell.LSP.Types.Capabilities as LSP
-import qualified Data.Text as T
-import Development.IDE.Types.Diagnostics
-import Control.DeepSeq (NFData(..))
-import Data.Aeson
-import GHC.Generics
 
 data IdeGhcSession = IdeGhcSession
   { loadSessionFun :: FilePath -> IO (IdeResult HscEnvEq, [FilePath])
@@ -49,52 +49,52 @@ instance Show IdeGhcSession where show _ = "IdeGhcSession"
 instance NFData IdeGhcSession where rnf !_ = ()
 
 data IdeOptions = IdeOptions
-  { optPreprocessor :: GHC.ParsedSource -> IdePreprocessedSource
+  { optPreprocessor       :: GHC.ParsedSource -> IdePreprocessedSource
     -- ^ Preprocessor to run over all parsed source trees, generating a list of warnings
     --   and a list of errors, along with a new parse tree.
-  , optGhcSession :: Action IdeGhcSession
+  , optGhcSession         :: Action IdeGhcSession
     -- ^ Setup a GHC session for a given file, e.g. @Foo.hs@.
     --   For the same 'ComponentOptions' from hie-bios, the resulting function will be applied once per file.
     --   It is desirable that many files get the same 'HscEnvEq', so that more IDE features work.
-  , optPkgLocationOpts :: IdePkgLocationOptions
+  , optPkgLocationOpts    :: IdePkgLocationOptions
     -- ^ How to locate source and @.hie@ files given a module name.
-  , optExtensions :: [String]
+  , optExtensions         :: [String]
     -- ^ File extensions to search for code, defaults to Haskell sources (including @.hs@)
 
-  , optThreads :: Int
+  , optThreads            :: Int
     -- ^ Number of threads to use. Use 0 for number of threads on the machine.
-  , optShakeFiles :: Maybe FilePath
+  , optShakeFiles         :: Maybe FilePath
   -- ^ Directory where the shake database should be stored. For ghcide this is always set to `Nothing` for now
   -- meaning we keep everything in memory but the daml CLI compiler uses this for incremental builds.
-  , optShakeProfiling :: Maybe FilePath
+  , optShakeProfiling     :: Maybe FilePath
     -- ^ Set to 'Just' to create a directory of profiling reports.
-  , optTesting :: IdeTesting
+  , optTesting            :: IdeTesting
     -- ^ Whether to enable additional lsp messages used by the test suite for checking invariants
-  , optReportProgress :: IdeReportProgress
+  , optReportProgress     :: IdeReportProgress
     -- ^ Whether to report progress during long operations.
-  , optLanguageSyntax :: String
+  , optLanguageSyntax     :: String
     -- ^ the ```language to use
   , optNewColonConvention :: Bool
     -- ^ whether to use new colon convention
-  , optKeywords :: [T.Text]
+  , optKeywords           :: [T.Text]
     -- ^ keywords used for completions. These are customizable
     -- since DAML has a different set of keywords than Haskell.
-  , optDefer :: IdeDefer
+  , optDefer              :: IdeDefer
     -- ^ Whether to defer type errors, typed holes and out of scope
     --   variables. Deferral allows the IDE to continue to provide
     --   features such as diagnostics and go-to-definition, in
     --   situations in which they would become unavailable because of
     --   the presence of type errors, holes or unbound variables.
-  , optCheckProject :: CheckProject
+  , optCheckProject       :: CheckProject
     -- ^ Whether to typecheck the entire project on load
-  , optCheckParents :: CheckParents
+  , optCheckParents       :: CheckParents
     -- ^ When to typecheck reverse dependencies of a file
-  , optHaddockParse :: OptHaddockParse
+  , optHaddockParse       :: OptHaddockParse
     -- ^ Whether to return result of parsing module with Opt_Haddock.
     --   Otherwise, return the result of parsing without Opt_Haddock, so
     --   that the parsed module contains the result of Opt_KeepRawTokenStream,
     --   which might be necessary for hlint.
-  , optCustomDynFlags :: DynFlags -> DynFlags
+  , optCustomDynFlags     :: DynFlags -> DynFlags
     -- ^ If given, it will be called right after setting up a new cradle,
     --   allowing to customize the Ghc options used
   }
@@ -128,9 +128,9 @@ defaultLspConfig = LspConfig CheckOnSaveAndClose (CheckProject True)
 data IdePreprocessedSource = IdePreprocessedSource
   { preprocWarnings :: [(GHC.SrcSpan, String)]
     -- ^ Warnings emitted by the preprocessor.
-  , preprocErrors :: [(GHC.SrcSpan, String)]
+  , preprocErrors   :: [(GHC.SrcSpan, String)]
     -- ^ Errors emitted by the preprocessor.
-  , preprocSource :: GHC.ParsedSource
+  , preprocSource   :: GHC.ParsedSource
     -- ^ New parse tree emitted by the preprocessor.
   }
 

--- a/test/exe/Main.hs
+++ b/test/exe/Main.hs
@@ -10,54 +10,56 @@
 
 module Main (main) where
 
-import Control.Applicative.Combinators
-import Control.Exception (bracket, catch)
-import qualified Control.Lens as Lens
-import Control.Monad
-import Control.Monad.IO.Class (liftIO)
-import Data.Aeson (FromJSON, Value, toJSON)
-import qualified Data.Binary as Binary
-import Data.Foldable
-import Data.List.Extra
-import Data.Maybe
-import Data.Rope.UTF16 (Rope)
-import qualified Data.Rope.UTF16 as Rope
-import Development.IDE.Core.PositionMapping (fromCurrent, toCurrent, PositionResult(..), positionResultToMaybe)
-import Development.IDE.Core.Shake (Q(..))
-import Development.IDE.GHC.Util
-import qualified Data.Text as T
-import Data.Typeable
-import Development.IDE.Spans.Common
-import Development.IDE.Test
-import Development.IDE.Test.Runfiles
-import Development.IDE.Types.Location
-import Development.Shake (getDirectoryFilesIO)
-import qualified Experiments as Bench
-import Language.Haskell.LSP.Test
-import Language.Haskell.LSP.Messages
-import Language.Haskell.LSP.Types
-import Language.Haskell.LSP.Types.Capabilities
-import qualified Language.Haskell.LSP.Types.Lens as Lsp (diagnostics, params, message)
-import Language.Haskell.LSP.VFS (applyChange)
-import Network.URI
-import System.Environment.Blank (getEnv, setEnv, unsetEnv)
-import System.FilePath
-import System.IO.Extra hiding (withTempDir)
+import           Control.Applicative.Combinators
+import           Control.Exception                       (bracket, catch)
+import qualified Control.Lens                            as Lens
+import           Control.Monad
+import           Control.Monad.IO.Class                  (liftIO)
+import           Data.Aeson                              (FromJSON, Value, toJSON)
+import qualified Data.Binary                             as Binary
+import           Data.Foldable
+import           Data.List.Extra
+import           Data.Maybe
+import           Data.Rope.UTF16                         (Rope)
+import qualified Data.Rope.UTF16                         as Rope
+import qualified Data.Text                               as T
+import           Data.Typeable
+import           Development.IDE.Core.PositionMapping    (PositionResult (..), fromCurrent, positionResultToMaybe,
+                                                          toCurrent)
+import           Development.IDE.Core.Shake              (Q (..))
+import           Development.IDE.GHC.Util
+import           Development.IDE.Plugin.CodeAction       (blockCommandId, typeSignatureCommandId)
+import           Development.IDE.Plugin.Test             (TestRequest (BlockSeconds, GetInterfaceFilesDir))
+import           Development.IDE.Spans.Common
+import           Development.IDE.Test
+import           Development.IDE.Test.Runfiles
+import           Development.IDE.Types.Location
+import           Development.Shake                       (getDirectoryFilesIO)
+import qualified Experiments                             as Bench
+import           Language.Haskell.LSP.Messages
+import           Language.Haskell.LSP.Test
+import           Language.Haskell.LSP.Types
+import           Language.Haskell.LSP.Types.Capabilities
+import qualified Language.Haskell.LSP.Types.Lens         as Lsp (diagnostics, message, params)
+import           Language.Haskell.LSP.VFS                (applyChange)
+import           Network.URI
+import           System.Directory
+import           System.Environment.Blank                (getEnv, setEnv, unsetEnv)
+import           System.Exit                             (ExitCode (ExitSuccess))
+import           System.FilePath
+import           System.IO.Extra                         hiding (withTempDir)
 import qualified System.IO.Extra
-import System.Directory
-import System.Exit (ExitCode(ExitSuccess))
-import System.Process.Extra (readCreateProcessWithExitCode, CreateProcess(cwd), proc)
-import System.Info.Extra (isWindows)
-import Test.QuickCheck
-import Test.QuickCheck.Instances ()
-import Test.Tasty
-import Test.Tasty.ExpectedFailure
-import Test.Tasty.Ingredients.Rerun
-import Test.Tasty.HUnit
-import Test.Tasty.QuickCheck
-import System.Time.Extra
-import Development.IDE.Plugin.CodeAction (typeSignatureCommandId, blockCommandId)
-import Development.IDE.Plugin.Test (TestRequest(BlockSeconds,GetInterfaceFilesDir))
+import           System.Info.Extra                       (isWindows)
+import           System.Process.Extra                    (CreateProcess (cwd), proc, readCreateProcessWithExitCode)
+import           System.Time.Extra
+import           Test.QuickCheck
+import           Test.QuickCheck.Instances               ()
+import           Test.Tasty
+import           Test.Tasty.ExpectedFailure
+import           Test.Tasty.HUnit
+import           Test.Tasty.Ingredients.Rerun
+import           Test.Tasty.QuickCheck
+
 
 main :: IO ()
 main = do
@@ -1711,7 +1713,7 @@ addFunctionConstraintTests = let
     , "eq :: " <> constraint <> " => Pair a b -> Pair a b -> Bool"
     , "eq (Pair x y) (Pair x' y') = x == x' && y == y'"
     ]
-  
+
   incompleteConstraintSourceCodeWithNewlinesInTypeSignature :: T.Text -> T.Text
   incompleteConstraintSourceCodeWithNewlinesInTypeSignature constraint =
     T.unlines

--- a/test/src/Development/IDE/Test.hs
+++ b/test/src/Development/IDE/Test.hs
@@ -4,32 +4,32 @@
 {-# LANGUAGE DuplicateRecordFields #-}
 
 module Development.IDE.Test
-  ( Cursor
-  , cursorPosition
-  , requireDiagnostic
-  , diagnostic
-  , expectDiagnostics
-  , expectDiagnosticsWithTags
-  , expectNoMoreDiagnostics
-  , canonicalizeUri
-  , standardizeQuotes
-  ) where
+    ( Cursor
+    , canonicalizeUri
+    , cursorPosition
+    , diagnostic
+    , expectDiagnostics
+    , expectDiagnosticsWithTags
+    , expectNoMoreDiagnostics
+    , requireDiagnostic
+    , standardizeQuotes
+    ) where
 
-import Control.Applicative.Combinators
-import Control.Lens hiding (List)
-import Control.Monad
-import Control.Monad.IO.Class
-import Data.Bifunctor (second)
-import qualified Data.Map.Strict as Map
-import qualified Data.Text as T
-import Language.Haskell.LSP.Test hiding (message)
-import qualified Language.Haskell.LSP.Test as LspTest
-import Language.Haskell.LSP.Types
-import Language.Haskell.LSP.Types.Lens as Lsp
-import System.Time.Extra
-import Test.Tasty.HUnit
-import System.Directory (canonicalizePath)
-import Data.Maybe (fromJust)
+import           Control.Applicative.Combinators
+import           Control.Lens                    hiding (List)
+import           Control.Monad
+import           Control.Monad.IO.Class
+import           Data.Bifunctor                  (second)
+import qualified Data.Map.Strict                 as Map
+import           Data.Maybe                      (fromJust)
+import qualified Data.Text                       as T
+import           Language.Haskell.LSP.Test       hiding (message)
+import qualified Language.Haskell.LSP.Test       as LspTest
+import           Language.Haskell.LSP.Types
+import           Language.Haskell.LSP.Types.Lens as Lsp
+import           System.Directory                (canonicalizePath)
+import           System.Time.Extra
+import           Test.Tasty.HUnit
 
 
 -- | (0-based line number, 0-based column number)


### PR DESCRIPTION
I have just used the default settings restricted to imports and module headers, enabling the new ghc-lib parser.