### PR TITLE
Do not show internal hole names

### DIFF
--- a/src/Development/IDE/Spans/AtPoint.hs
+++ b/src/Development/IDE/Spans/AtPoint.hs
@@ -115,7 +115,7 @@ atPoint IdeOptions{} hf (DKMap dm km) pos = listToMaybe $ pointCommand hf pos ho
         prettyNames :: [T.Text]
         prettyNames = map prettyName names
         prettyName (Right n, dets) = T.unlines $
-          wrapHaskell (showUnqualifiedName n <> maybe "" ((" :: " <>) . prettyType) (identType dets <|> maybeKind))
+          wrapHaskell (showNameWithoutUniques n <> maybe "" ((" :: " <>) . prettyType) (identType dets <|> maybeKind))
           : definedAt n
           ++ catMaybes [ T.unlines . spanDocToMarkdown <$> lookupNameEnv dm n
                       ]

--- a/src/Development/IDE/Spans/AtPoint.hs
+++ b/src/Development/IDE/Spans/AtPoint.hs
@@ -41,7 +41,6 @@ import           Data.Maybe
 import           Data.List
 import qualified Data.Text as T
 import qualified Data.Map as M
-import qualified Text.Regex.TDFA as R
 
 import Data.Either
 import Data.List.Extra (dropEnd1)

--- a/src/Development/IDE/Spans/AtPoint.hs
+++ b/src/Development/IDE/Spans/AtPoint.hs
@@ -115,17 +115,12 @@ atPoint IdeOptions{} hf (DKMap dm km) pos = listToMaybe $ pointCommand hf pos ho
         prettyNames :: [T.Text]
         prettyNames = map prettyName names
         prettyName (Right n, dets) = T.unlines $
-          wrapHaskell (showName' n <> maybe "" ((" :: " <>) . prettyType) (identType dets <|> maybeKind))
+          wrapHaskell (showUnqualifiedName n <> maybe "" ((" :: " <>) . prettyType) (identType dets <|> maybeKind))
           : definedAt n
           ++ catMaybes [ T.unlines . spanDocToMarkdown <$> lookupNameEnv dm n
                       ]
           where maybeKind = safeTyThingType =<< lookupNameEnv km n
-        prettyName (Left m,_) = showName' m
-
-        showName' (showName -> nm)
-          | nm R.=~ ("_[^_]*_.....?" :: T.Text)
-                      = "_"
-          | otherwise = nm
+        prettyName (Left m,_) = showName m
 
         prettyTypes = map (("_ :: "<>) . prettyType) types
         prettyType t = showName t

--- a/src/Development/IDE/Spans/Common.hs
+++ b/src/Development/IDE/Spans/Common.hs
@@ -6,6 +6,7 @@
 module Development.IDE.Spans.Common (
   showGhc
 , showName
+, showUnqualifiedName
 , safeTyThingId
 , safeTyThingType
 , SpanDoc(..)
@@ -29,6 +30,7 @@ import DynFlags
 import ConLike
 import DataCon
 import Var
+import Name (pprNameUnqualified)
 import NameEnv
 
 import qualified Documentation.Haddock.Parser as H
@@ -45,6 +47,12 @@ showName :: Outputable a => a -> T.Text
 showName = T.pack . prettyprint
   where
     prettyprint x = renderWithStyle unsafeGlobalDynFlags (ppr x) style
+    style = mkUserStyle unsafeGlobalDynFlags neverQualify AllTheWay
+
+showUnqualifiedName :: Name -> T.Text
+showUnqualifiedName = T.pack . prettyprint
+  where
+    prettyprint x = renderWithStyle unsafeGlobalDynFlags (pprNameUnqualified x) style
     style = mkUserStyle unsafeGlobalDynFlags neverQualify AllTheWay
 
 -- From haskell-ide-engine/src/Haskell/Ide/Engine/Support/HieExtras.hs

--- a/src/Development/IDE/Spans/Common.hs
+++ b/src/Development/IDE/Spans/Common.hs
@@ -6,7 +6,7 @@
 module Development.IDE.Spans.Common (
   showGhc
 , showName
-, showUnqualifiedName
+, showNameWithoutUniques
 , safeTyThingId
 , safeTyThingType
 , SpanDoc(..)
@@ -30,7 +30,6 @@ import DynFlags
 import ConLike
 import DataCon
 import Var
-import Name (pprNameUnqualified)
 import NameEnv
 
 import qualified Documentation.Haddock.Parser as H
@@ -49,11 +48,12 @@ showName = T.pack . prettyprint
     prettyprint x = renderWithStyle unsafeGlobalDynFlags (ppr x) style
     style = mkUserStyle unsafeGlobalDynFlags neverQualify AllTheWay
 
-showUnqualifiedName :: Name -> T.Text
-showUnqualifiedName = T.pack . prettyprint
+showNameWithoutUniques :: Outputable a => a -> T.Text
+showNameWithoutUniques = T.pack . prettyprint
   where
-    prettyprint x = renderWithStyle unsafeGlobalDynFlags (pprNameUnqualified x) style
-    style = mkUserStyle unsafeGlobalDynFlags neverQualify AllTheWay
+    dyn = unsafeGlobalDynFlags `gopt_set` Opt_SuppressUniques
+    prettyprint x = renderWithStyle dyn (ppr x) style
+    style = mkUserStyle dyn neverQualify AllTheWay
 
 -- From haskell-ide-engine/src/Haskell/Ide/Engine/Support/HieExtras.hs
 safeTyThingType :: TyThing -> Maybe Type

--- a/test/data/hover/GotoHover.hs
+++ b/test/data/hover/GotoHover.hs
@@ -55,3 +55,6 @@ outer = undefined inner where
 
 imported :: Bar
 imported = foo
+
+hole :: Int
+hole = _

--- a/test/exe/Main.hs
+++ b/test/exe/Main.hs
@@ -1115,13 +1115,13 @@ suggestImportTests = testGroup "suggest import actions"
     test' waitForCheckProject wanted imps def other newImp = testSessionWithExtraFiles "hover" (T.unpack def) $ \dir -> do
       let before = T.unlines $ "module A where" : ["import " <> x | x <- imps] ++ def : other
           after  = T.unlines $ "module A where" : ["import " <> x | x <- imps] ++ [newImp] ++ def : other
-          cradle = "cradle: {direct: {arguments: [-hide-all-packages, -package, base, -package, text, -package-env, -, A, Bar, Foo, GotoHover]}}"
+          cradle = "cradle: {direct: {arguments: [-hide-all-packages, -package, base, -package, text, -package-env, -, A, Bar, Foo]}}"
       liftIO $ writeFileUTF8 (dir </> "hie.yaml") cradle
       doc <- createDoc "Test.hs" "haskell" before
       void (skipManyTill anyMessage message :: Session WorkDoneProgressEndNotification)
       _diags <- waitForDiagnostics
       -- there isn't a good way to wait until the whole project is checked atm
-      when waitForCheckProject $ liftIO $ sleep 1
+      when waitForCheckProject $ liftIO $ sleep 0.5
       let defLine = length imps + 1
           range = Range (Position defLine 0) (Position defLine maxBound)
       actions <- getCodeActions doc range

--- a/test/exe/Main.hs
+++ b/test/exe/Main.hs
@@ -1711,7 +1711,7 @@ addFunctionConstraintTests = let
     , "eq :: " <> constraint <> " => Pair a b -> Pair a b -> Bool"
     , "eq (Pair x y) (Pair x' y') = x == x' && y == y'"
     ]
-  
+
   incompleteConstraintSourceCodeWithNewlinesInTypeSignature :: T.Text -> T.Text
   incompleteConstraintSourceCodeWithNewlinesInTypeSignature constraint =
     T.unlines
@@ -2234,6 +2234,7 @@ findDefinitionAndHoverTests = let
   lstL43 = Position 47 12  ;  litL   = [ExpectHoverText ["[8391 :: Int, 6268]"]]
   outL45 = Position 49  3  ;  outSig = [ExpectHoverText ["outer", "Bool"], mkR 46 0 46 5]
   innL48 = Position 52  5  ;  innSig = [ExpectHoverText ["inner", "Char"], mkR 49 2 49 7]
+  holeL60 = Position 59 7  ;  hleInfo = [ExpectHoverText ["_ ::"]]
   cccL17 = Position 17 11  ;  docLink = [ExpectHoverText ["[Documentation](file:///"]]
   imported = Position 56 13 ; importedSig = getDocUri "Foo.hs" >>= \foo -> return [ExpectHoverText ["foo", "Foo", "Haddock"], mkL foo 5 0 5 3]
   reexported = Position 55 14 ; reexportedSig = getDocUri "Bar.hs" >>= \bar -> return [ExpectHoverText ["Bar", "Bar", "Haddock"], mkL bar 3 0 3 14]
@@ -2279,6 +2280,7 @@ findDefinitionAndHoverTests = let
   , test  no     broken docL41     constr        "type constraint in hover info   #283"
   , test  broken broken outL45     outSig        "top-level signature             #310"
   , test  broken broken innL48     innSig        "inner     signature             #310"
+  , test  no     yes    holeL60    hleInfo       "hole without internal name      #847"
   , test  no     yes    cccL17     docLink       "Haddock html links"
   , testM yes    yes    imported   importedSig   "Imported symbol"
   , testM yes    yes    reexported reexportedSig "Imported symbol (reexported)"

--- a/test/exe/Main.hs
+++ b/test/exe/Main.hs
@@ -1121,7 +1121,7 @@ suggestImportTests = testGroup "suggest import actions"
       void (skipManyTill anyMessage message :: Session WorkDoneProgressEndNotification)
       _diags <- waitForDiagnostics
       -- there isn't a good way to wait until the whole project is checked atm
-      when waitForCheckProject $ liftIO $ sleep 0.5
+      when waitForCheckProject $ liftIO $ sleep 1
       let defLine = length imps + 1
           range = Range (Position defLine 0) (Position defLine maxBound)
       actions <- getCodeActions doc range

--- a/test/exe/Main.hs
+++ b/test/exe/Main.hs
@@ -2184,7 +2184,9 @@ findDefinitionAndHoverTests = let
   mkFindTests tests = testGroup "get"
     [ testGroup "definition" $ mapMaybe fst tests
     , testGroup "hover"      $ mapMaybe snd tests
-    , checkFileCompiles sourceFilePath
+    , checkFileCompiles sourceFilePath $
+        expectDiagnostics
+          [ ( "GotoHover.hs", [(DsError, (59, 7), "Found hole: _")]) ]
     , testGroup "type-definition" typeDefinitionTests ]
 
   typeDefinitionTests = [ tst (getTypeDefinitions, checkDefs) aaaL14 (pure tcData) "Saturated data con"
@@ -2290,11 +2292,11 @@ findDefinitionAndHoverTests = let
         broken = Just . (`xfail` "known broken")
         no = const Nothing -- don't run this test at all
 
-checkFileCompiles :: FilePath -> TestTree
-checkFileCompiles fp =
+checkFileCompiles :: FilePath -> Session () -> TestTree
+checkFileCompiles fp diag =
   testSessionWithExtraFiles "hover" ("Does " ++ fp ++ " compile") $ \dir -> do
     void (openTestDataDoc (dir </> fp))
-    expectNoMoreDiagnostics 0.5
+    diag
 
 pluginSimpleTests :: TestTree
 pluginSimpleTests =


### PR DESCRIPTION
Fixes #847 

This PR solves both problems:
- It contains a regular expression to catch internal names for holes `/_[^_]*_.....?/` and rewrite them to `_`,
- It ensures that "no location info" is not shown by filtering out "unhelpful locations"