### PR TITLE
Preserve envImportPaths in GhcSessionDeps

### DIFF
--- a/src/Development/IDE/Core/Rules.hs
+++ b/src/Development/IDE/Core/Rules.hs
@@ -665,7 +665,8 @@ loadGhcSession = do
 
 ghcSessionDepsDefinition :: NormalizedFilePath -> Action (IdeResult HscEnvEq)
 ghcSessionDepsDefinition file = do
-        hsc <- hscEnv <$> use_ GhcSession file
+        env <- use_ GhcSession file
+        let hsc = hscEnv env
         (deps,_) <- useWithStale_ GetDependencies file
         let tdeps = transitiveModuleDeps deps
         ifaces <- uses_ GetModIface tdeps
@@ -679,7 +680,7 @@ ghcSessionDepsDefinition file = do
             setupFinderCache (map hirModSummary ifaces)
             mapM_ loadDepModule inLoadOrder
 
-        res <- liftIO $ newHscEnvEq "" session' []
+        res <- liftIO $ newHscEnvEqWithImportPaths (envImportPaths env) session' []
         return ([], Just res)
 
 getModIfaceFromDiskRule :: Rules ()

--- a/src/Development/IDE/GHC/Util.hs
+++ b/src/Development/IDE/GHC/Util.hs
@@ -31,7 +31,8 @@ module Development.IDE.GHC.Util(
     setHieDir,
     dontWriteHieFiles,
     disableWarningsAsErrors,
-    newHscEnvEqPreserveImportPaths) where
+    newHscEnvEqPreserveImportPaths,
+    newHscEnvEqWithImportPaths) where
 
 import Control.Concurrent
 import Data.List.Extra
@@ -191,6 +192,11 @@ newHscEnvEq cradlePath hscEnv0 deps = do
     let envImportPaths = Just $ relativeToCradle <$> importPaths (hsc_dflags hscEnv0)
         relativeToCradle = (takeDirectory cradlePath </>)
         hscEnv = removeImportPaths hscEnv0
+    return HscEnvEq{..}
+
+newHscEnvEqWithImportPaths :: Maybe [String] -> HscEnv -> [(InstalledUnitId, DynFlags)] -> IO HscEnvEq
+newHscEnvEqWithImportPaths envImportPaths hscEnv deps = do
+    envUnique <- newUnique
     return HscEnvEq{..}
 
 -- | Wrap an 'HscEnv' into an 'HscEnvEq'.


### PR DESCRIPTION
The Eval plugin in hls needs to retrieve the import paths from the value returned by the `GhcSessionDeps` rule. 
More details in https://github.com/haskell/haskell-language-server/pull/488