### PR TITLE
Use -fexternal-interpreter and WayDyn, fix recompilation checking for object files

### DIFF
--- a/ghcide.cabal
+++ b/ghcide.cabal
@@ -49,6 +49,7 @@ library
         fuzzy,
         filepath,
         fingertree,
+        process,
         Glob,
         haddock-library >= 1.8,
         hashable,

--- a/session-loader/Development/IDE/Session.hs
+++ b/session-loader/Development/IDE/Session.hs
@@ -371,7 +371,7 @@ emptyHscEnv :: IORef NameCache -> FilePath -> IO HscEnv
 emptyHscEnv nc libDir = do
     env <- runGhc (Just libDir) getSession
     initDynLinker env
-    pure $ setNameCache nc env
+    pure $ let x = setNameCache nc env in x {hsc_dflags = addWay' WayDyn $ gopt_set (hsc_dflags x) Opt_ExternalInterpreter }
 
 data TargetDetails = TargetDetails
   {

--- a/src/Development/IDE/Core/Compile.hs
+++ b/src/Development/IDE/Core/Compile.hs
@@ -275,7 +275,9 @@ generateObjectCode hscEnv summary guts = do
                                 fp
                       compileFile session' StopLn (outputFilename, Just (As False))
               let unlinked = DotO dot_o_fp
-              let linkable = LM (ms_hs_date summary) (ms_mod summary) [unlinked]
+              -- Need time to be the modification time for recompilation checking
+              t <- liftIO $ getModificationTime dot_o_fp
+              let linkable = LM t (ms_mod summary) [unlinked]
               pure (map snd warnings, linkable)
 
 generateByteCode :: HscEnv -> ModSummary -> CgGuts -> IO (IdeResult Linkable)
@@ -479,7 +481,7 @@ loadModuleHome
     -> HscEnv
     -> HscEnv
 loadModuleHome mod_info e =
-    e { hsc_HPT = addToHpt (hsc_HPT e) mod_name mod_info }
+    e { hsc_HPT = addToHpt (hsc_HPT e) mod_name mod_info, hsc_type_env_var = Nothing }
     where
       mod_name = moduleName $ mi_module $ hm_iface mod_info
 

--- a/src/Development/IDE/Core/Compile.hs
+++ b/src/Development/IDE/Core/Compile.hs
@@ -227,7 +227,7 @@ initPlugins modSummary = do
     session <- getSession
     let df0 = flip gopt_unset Opt_ExternalInterpreter $ ms_hspp_opts modSummary
     dflags <- liftIO $ initializePlugins session df0{ ways = filter (WayDyn /=) (ways df0) }
-    return modSummary{ms_hspp_opts = flip gopt_set Opt_ExternalInterpreter $ addWay' WayDyn $ dflags}
+    return modSummary{ms_hspp_opts = flip gopt_set Opt_ExternalInterpreter $ addWay' WayDyn dflags}
 
 -- | Whether we should run the -O0 simplifier when generating core.
 --

--- a/src/Development/IDE/Core/Compile.hs
+++ b/src/Development/IDE/Core/Compile.hs
@@ -162,7 +162,7 @@ typecheckModule (IdeDefer defer) hsc pm = do
 modifyPLS :: DynLinker -> (PersistentLinkerState -> IO (PersistentLinkerState, a)) -> IO a
 modifyPLS dl f =
   modifyMVar (dl_mpls dl) (fmapFst pure . f . fromMaybe undefined)
-  where fmapFst f = fmap (\(x, y) -> (f x, y))
+  where fmapFst f = fmap (first f)
 
 modifyMbPLS_
   :: DynLinker -> (Maybe PersistentLinkerState -> IO (Maybe PersistentLinkerState)) -> IO ()
@@ -202,10 +202,10 @@ tcRnModule pmod = do
   hsc_env <- getSession
   let hsc_env_tmp = hsc_env { hsc_dflags =  ms_hspp_opts ms }
   (tc_gbl_env, mrn_info)
-        <- (liftIO $ hscTypecheckRename hsc_env_tmp ms $
+        <- liftIO $ hscTypecheckRename hsc_env_tmp ms $
                        HsParsedModule { hpm_module = parsedSource pmod,
                                         hpm_src_files = pm_extra_src_files pmod,
-                                        hpm_annotations = pm_annotations pmod })
+                                        hpm_annotations = pm_annotations pmod }
   let rn_info = case mrn_info of
         Just x -> x
         Nothing -> error "no renamed info tcRnModule"

--- a/src/Development/IDE/Core/Preprocessor.hs
+++ b/src/Development/IDE/Core/Preprocessor.hs
@@ -146,7 +146,7 @@ parsePragmasIntoDynFlags env fp contents = catchSrcErrors "pragmas" $ do
     liftIO $ evaluate $ rnf opts
 
     (dflags, _, _) <- parseDynamicFilePragma dflags0 opts
-    dflags' <- liftIO $ initializePlugins env $ flip gopt_unset Opt_ExternalInterpreter dflags{ways = filter (WayDyn /=) (ways dflags) }
+    dflags' <- liftIO $ initializePlugins env $ gopt_unset dflags{ways = filter (WayDyn /=) (ways dflags) } Opt_ExternalInterpreter
     return $ disableWarningsAsErrors $ flip gopt_set Opt_ExternalInterpreter $ addWay' WayDyn dflags'
 
 -- | Run (unlit) literate haskell preprocessor on a file, or buffer if set

--- a/src/Development/IDE/Core/Preprocessor.hs
+++ b/src/Development/IDE/Core/Preprocessor.hs
@@ -146,8 +146,8 @@ parsePragmasIntoDynFlags env fp contents = catchSrcErrors "pragmas" $ do
     liftIO $ evaluate $ rnf opts
 
     (dflags, _, _) <- parseDynamicFilePragma dflags0 opts
-    dflags' <- liftIO $ initializePlugins env dflags
-    return $ disableWarningsAsErrors dflags'
+    dflags' <- liftIO $ initializePlugins env $ flip gopt_unset Opt_ExternalInterpreter dflags{ways = filter (WayDyn /=) (ways dflags) }
+    return $ disableWarningsAsErrors $ flip gopt_set Opt_ExternalInterpreter $ addWay' WayDyn dflags'
 
 -- | Run (unlit) literate haskell preprocessor on a file, or buffer if set
 runLhs :: DynFlags -> FilePath -> Maybe SB.StringBuffer -> IO SB.StringBuffer

--- a/src/Development/IDE/Core/RuleTypes.hs
+++ b/src/Development/IDE/Core/RuleTypes.hs
@@ -36,7 +36,6 @@ import Data.ByteString (ByteString)
 import Language.Haskell.LSP.Types (NormalizedFilePath)
 import TcRnMonad (TcGblEnv)
 import qualified Data.ByteString.Char8 as BS
-import Debug.Trace
 
 -- NOTATION
 --   Foo+ means Foo for the dependencies
@@ -113,9 +112,8 @@ data HiFileResult = HiFileResult
     }
 
 hiFileFingerPrint :: HiFileResult -> ByteString
-hiFileFingerPrint hfr = traceShow (hfr, res) res
+hiFileFingerPrint hfr = ifaceBS <> linkableBS
   where
-    res = ifaceBS <> linkableBS
     ifaceBS = fingerprintToBS . getModuleHash . hirModIface $ hfr -- will always be two bytes
     linkableBS = case hm_linkable $ hirHomeMod hfr of
       Nothing -> ""

--- a/test/exe/Main.hs
+++ b/test/exe/Main.hs
@@ -2472,9 +2472,9 @@ thTests =
         _ <- createDoc "A.hs" "haskell" sourceA
         _ <- createDoc "B.hs" "haskell" sourceB
         return ()
-    , ignoreInWindowsForGHC88 (thReloadingTest `xfail` "expect broken (#672)")
+    , thReloadingTest
     -- Regression test for https://github.com/digital-asset/ghcide/issues/614
-    , thLinkingTest `xfail` "expect broken"
+    , thLinkingTest
     , testSessionWait "findsTHIdentifiers" $ do
         let sourceA =
               T.unlines
@@ -2534,6 +2534,7 @@ thReloadingTest = testCase "reloading-th-test" $ withoutStackEnv $ runWithExtraF
     expectDiagnostics
         [("THC.hs", [(DsError, (4, 4), "Couldn't match expected type '()' with actual type 'Bool'")])
         ,("THC.hs", [(DsWarning, (6,0), "Top-level binding")])
+        ,("THB.hs", [(DsWarning, (4,0), "Top-level binding")])
         ]
 
     closeDoc adoc


### PR DESCRIPTION
Needs a lot of tests, especially on windows

Fixes #854 and #672 
No need for #858 

