### PR TITLE
Add code action for remove all redundant imports

### DIFF
--- a/src/Development/IDE/Plugin/CodeAction.hs
+++ b/src/Development/IDE/Plugin/CodeAction.hs
@@ -221,16 +221,14 @@ caRemoveRedundantImports m contents digs ctxDigs uri
         _documentChanges = Nothing
         _edit = Just WorkspaceEdit{..}
         _command = Nothing
-    removeAll tedit
-      | _changes <- Just $ Map.singleton uri $ List tedit,
-        _title <- "Remove all redundant imports",
-        _kind <- Just CodeActionQuickFix,
-        _diagnostics <- Nothing,
-        _documentChanges <- Nothing,
-        _edit <- Just WorkspaceEdit{..},
-        _command <- Nothing
-          = [CACodeAction CodeAction {..}]
-      | otherwise = []
+    removeAll tedit = [CACodeAction CodeAction {..}] where
+        _changes = Just $ Map.singleton uri $ List tedit
+        _title = "Remove all redundant imports"
+        _kind = Just CodeActionQuickFix
+        _diagnostics = Nothing
+        _documentChanges = Nothing
+        _edit = Just WorkspaceEdit{..}
+        _command = Nothing
 
 suggestDeleteUnusedBinding :: ParsedModule -> Maybe T.Text -> Diagnostic -> [(T.Text, [TextEdit])]
 suggestDeleteUnusedBinding

--- a/src/Development/IDE/Plugin/CodeAction.hs
+++ b/src/Development/IDE/Plugin/CodeAction.hs
@@ -213,16 +213,14 @@ caRemoveRedundantImports m contents digs ctxDigs uri
       = caRemoveCtx ++ caRemoveAll
   | otherwise = []
   where
-    removeSingle title tedit diagnostic
-      | _changes <- Just $ Map.singleton uri $ List tedit,
-        _title <- title,
-        _kind <- Just CodeActionQuickFix,
-        _diagnostics <- Just $ List [diagnostic],
-        _documentChanges <- Nothing,
-        _edit <- Just WorkspaceEdit{..},
-        _command <- Nothing
-         = [CACodeAction CodeAction {..}]
-      | otherwise = []
+    removeSingle title tedit diagnostic = [CACodeAction CodeAction{..}] where
+        _changes = Just $ Map.singleton uri $ List tedit
+        _title = title
+        _kind = Just CodeActionQuickFix
+        _diagnostics = Just $ List [diagnostic]
+        _documentChanges = Nothing
+        _edit = Just WorkspaceEdit{..}
+        _command = Nothing
     removeAll tedit
       | _changes <- Just $ Map.singleton uri $ List tedit,
         _title <- "Remove all redundant imports",


### PR DESCRIPTION
This PR implements https://github.com/haskell/haskell-language-server/issues/339. The code removing single redundant import can be reused.