### PR TITLE
Canonicalize import dirs

### DIFF
--- a/test/exe/Main.hs
+++ b/test/exe/Main.hs
@@ -3010,7 +3010,7 @@ expectFailCabal = expectFailBecause
 #endif
 
 ignoreInWindowsBecause :: String -> TestTree -> TestTree
-ignoreInWindowsBecause = if isWindows then ignoreTestBecause else flip const
+ignoreInWindowsBecause = if isWindows then ignoreTestBecause else (\_ x -> x)
 
 ignoreInWindowsForGHC88And810 :: TestTree -> TestTree
 #if MIN_GHC_API_VERSION(8,8,1) && !MIN_GHC_API_VERSION(9,0,0)


### PR DESCRIPTION
This is a bug fix that only applies when using file targets with symlinks. The locate imports logic performs an equality check for file targets and import dirs, and this goes wrong currently since we only canonicalise file targets, but not import dirs. 