### PR TITLE
Fix pretty printer for diagnostic ranges

### DIFF
--- a/src/Development/IDE/Types/Diagnostics.hs
+++ b/src/Development/IDE/Types/Diagnostics.hs
@@ -89,7 +89,7 @@ type FileDiagnostic = (NormalizedFilePath, ShowDiagnostic, Diagnostic)
 
 prettyRange :: Range -> Doc Terminal.AnsiStyle
 prettyRange Range{..} = f _start <> "-" <> f _end
-    where f Position{..} = pretty (_line+1) <> colon <> pretty _character
+    where f Position{..} = pretty (_line+1) <> colon <> pretty (_character+1)
 
 stringParagraphs :: T.Text -> Doc a
 stringParagraphs = vcat . map (fillSep . map pretty . T.words) . T.lines


### PR DESCRIPTION
With the current implementation, VS Code will show "1:1" for the top
left corner, but the pretty printer renders this poisition to "1:0".
This is particularly interesting for people building command line tools
using `ghcide`, like the our DAML compiler at Digital Asset.
tools with command line drivers, like us at Digital Asset.

I would argue that VS Code has the ultimate authority on this since we
can't change what it displays without also moving the squiggly lines.

This PR fixes the discrepance by simply adding one to the column number
in the prtty printer, like we do for the line number.