### PR TITLE
Use hole fit plugins to record holes instead of parsing error messages

### DIFF
--- a/test/exe/Main.hs
+++ b/test/exe/Main.hs
@@ -1633,7 +1633,7 @@ fillTypedHoleTests = let
   , check "replace _c with parameterInt"
           "_a" "_b" "_c"
           "_a" "_b"  "parameterInt"
-  , check "replace _ with foo _"
+  , check "replace _ with (foo _)"
           "_" "n" "n"
           "(foo _)" "n" "n"
   ]


### PR DESCRIPTION
Only works on 8.10+, so we would need to keep the parsing logic by CPPing the rest.

/cc @isovector I think this approach will provide a more robust way to get the local environment (`TcGblEnv`/`TcLclEnv`) at a hole, instead of going through `LocalBindings`. Thoughts? The tactic logic could work entirely inside `TcRn`.