### PR TITLE
Disable CI benchmark suite

### DIFF
--- a/.azure/linux-bench.yml
+++ b/.azure/linux-bench.yml
@@ -32,6 +32,8 @@ jobs:
       fi
       mkdir -p $STACK_ROOT
     displayName: 'Install Stack'
+  - bash: stack --version
+    displayName: 'stack version'
   - bash: stack setup --stack-yaml=$STACK_YAML
     displayName: 'stack setup'
   - bash: stack build --bench --only-dependencies --stack-yaml=$STACK_YAML

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,4 +16,6 @@ pr:
 jobs:
   - template: ./.azure/linux-stack.yml
   - template: ./.azure/windows-stack.yml
-  - template: ./.azure/linux-bench.yml
+
+# Disable benchmarks until we can figure out why they get stuck
+  # - template: ./.azure/linux-bench.yml


### PR DESCRIPTION
It appears that the benchmark suite gets stuck due to `stack exec` grabbing a file lock that it didn't use to. 

This PR is to debug the issues to try find a fix or workaround

```

ghcide> still blocking for directory lock on /home/vsts/work/1/s/.stack-work/dist/x86_64-linux/Cabal-2.4.0.1/build-lock; maybe another Stack process is running?
ghcide> still blocking for directory lock on /home/vsts/work/1/s/.stack-work/dist/x86_64-linux/Cabal-2.4.0.1/build-lock; maybe another Stack process is running?
ghcide> still blocking for directory lock on /home/vsts/work/1/s/.stack-work/dist/x86_64-linux/Cabal-2.4.0.1/build-lock; maybe another Stack process is running?
```