### PR TITLE
Hide warnings which user hasn't explicitly enabled

### DIFF
--- a/src/Development/IDE/Core/Compile.hs
+++ b/src/Development/IDE/Core/Compile.hs
@@ -332,12 +332,12 @@ upgradeWarningToError (nfp, sh, fd) =
   warn2err = T.intercalate ": error:" . T.splitOn ": warning:"
 
 hideDiag :: DynFlags -> (WarnReason, FileDiagnostic) -> (WarnReason, FileDiagnostic)
-hideDiag originalFlags (Reason warning, (nfp, sh, fd))
+hideDiag originalFlags (Reason warning, (nfp, _sh, fd))
   | not (wopt warning originalFlags)
   = if null (_tags fd)
        then (Reason warning, (nfp, HideDiag, fd))
             -- keep the diagnostic if it has an associated tag
-       else (Reason warning, (nfp, sh, fd{_severity = Just DsInfo}))
+       else (Reason warning, (nfp, HideDiag, fd{_severity = Just DsInfo}))
 hideDiag _originalFlags t = t
 
 enableUnnecessaryAndDeprecationWarnings :: ParsedModule -> ParsedModule


### PR DESCRIPTION
Patches #815. 

This seems to result in the right behaviour, but I don't quite understand the logic in `hideDiag`. @serras Why exactly do we match on the existence of a tag in the diagnostic, without caring which tag it is?

Closes haskell/haskell-language-server#572.