### PR TITLE
Avoid calling kick explicitly

### DIFF
--- a/exe/Main.hs
+++ b/exe/Main.hs
@@ -50,6 +50,7 @@ import qualified Data.HashMap.Strict as HashMap
 import qualified Data.Aeson as J
 
 import HIE.Bios.Cradle
+import Development.IDE (action)
 
 ghcideVersion :: IO String
 ghcideVersion = do
@@ -113,7 +114,7 @@ main = do
                     }
                 logLevel = if argsVerbose then minBound else Info
             debouncer <- newAsyncDebouncer
-            initialise caps (mainRule >> pluginRules plugins)
+            initialise caps (mainRule >> pluginRules plugins >> action kick)
                 getLspId event wProg wIndefProg (logger logLevel) debouncer options vfs
     else do
         -- GHC produces messages with UTF8 in them, so make sure the terminal doesn't error

--- a/session-loader/Development/IDE/Session.hs
+++ b/session-loader/Development/IDE/Session.hs
@@ -31,7 +31,6 @@ import Data.IORef
 import Data.Maybe
 import Data.Time.Clock
 import Data.Version
-import Development.IDE.Core.OfInterest
 import Development.IDE.Core.Shake
 import Development.IDE.Core.RuleTypes
 import Development.IDE.GHC.Compat hiding (Target, TargetModule, TargetFile)
@@ -245,7 +244,7 @@ loadSession dir = do
 
           -- Invalidate all the existing GhcSession build nodes by restarting the Shake session
           invalidateShakeCache
-          restartShakeSession [kick]
+          restartShakeSession []
 
           -- Typecheck all files in the project on startup
           unless (null cs || not checkProject) $ do

--- a/src/Development/IDE/Core/FileStore.hs
+++ b/src/Development/IDE/Core/FileStore.hs
@@ -36,7 +36,7 @@ import System.IO.Error
 import qualified Data.ByteString.Char8 as BS
 import Development.IDE.Types.Diagnostics
 import Development.IDE.Types.Location
-import Development.IDE.Core.OfInterest (getFilesOfInterest, kick)
+import Development.IDE.Core.OfInterest (getFilesOfInterest)
 import Development.IDE.Core.RuleTypes
 import Development.IDE.Types.Options
 import qualified Data.Rope.UTF16 as Rope
@@ -226,7 +226,7 @@ setFileModified state saved nfp = do
     VFSHandle{..} <- getIdeGlobalState state
     when (isJust setVirtualFileContents) $
         fail "setFileModified can't be called on this type of VFSHandle"
-    shakeRestart state [kick]
+    shakeRestart state []
     when checkParents $
       typecheckParents state nfp
 
@@ -252,4 +252,4 @@ setSomethingModified state = do
     VFSHandle{..} <- getIdeGlobalState state
     when (isJust setVirtualFileContents) $
         fail "setSomethingModified can't be called on this type of VFSHandle"
-    void $ shakeRestart state [kick]
+    void $ shakeRestart state []

--- a/src/Development/IDE/Core/OfInterest.hs
+++ b/src/Development/IDE/Core/OfInterest.hs
@@ -88,8 +88,8 @@ modifyFilesOfInterest state f = do
 
 -- | Typecheck all the files of interest.
 --   Could be improved
-kick :: DelayedAction ()
-kick = mkDelayedAction "kick" Debug $ do
+kick :: Action ()
+kick = do
     files <- HashMap.keys <$> getFilesOfInterest
     ShakeExtras{progressUpdate} <- getShakeExtras
     liftIO $ progressUpdate KickStarted

--- a/src/Development/IDE/Types/Options.hs
+++ b/src/Development/IDE/Types/Options.hs
@@ -95,7 +95,7 @@ data IdeOptions = IdeOptions
     --   that the parsed module contains the result of Opt_KeepRawTokenStream,
     --   which might be necessary for hlint.
   , optCustomDynFlags :: DynFlags -> DynFlags
-    -- ^ If given, it will be called right after setting up a new cradle,
+    -- ^ Will be called right after setting up a new cradle,
     --   allowing to customize the Ghc options used
   }
 


### PR DESCRIPTION
This change leverages that rules are rerun by shakeRunDatabase.
It allows users of ghcide as a library to use their own kick