### PR TITLE
Make Filetargets absolute before continue using them

### DIFF
--- a/session-loader/Development/IDE/Session.hs
+++ b/session-loader/Development/IDE/Session.hs
@@ -617,7 +617,8 @@ memoIO op = do
 -- | Throws if package flags are unsatisfiable
 setOptions :: GhcMonad m => ComponentOptions -> DynFlags -> m (DynFlags, [GHC.Target])
 setOptions (ComponentOptions theOpts compRoot _) dflags = do
-    (dflags', targets) <- addCmdOpts theOpts dflags
+    (dflags', targets') <- addCmdOpts theOpts dflags
+    let targets = makeTargetsAbsolute compRoot targets'
     let dflags'' =
           disableWarningsAsErrors $
           -- disabled, generated directly by ghcide instead

--- a/test/data/cabal-exe/a/a.cabal
+++ b/test/data/cabal-exe/a/a.cabal
@@ -1,0 +1,14 @@
+cabal-version:       2.2
+
+name:                a
+version:             0.1.0.0
+author:              Fendor
+maintainer:          power.walross@gmail.com
+build-type:          Simple
+
+executable a
+  main-is:             Main.hs
+  hs-source-dirs:      src
+  ghc-options:         -Wall
+  build-depends:       base
+  default-language:    Haskell2010

--- a/test/data/cabal-exe/a/src/Main.hs
+++ b/test/data/cabal-exe/a/src/Main.hs
@@ -1,0 +1,3 @@
+module Main where
+
+main = putStrLn "Hello, Haskell!"

--- a/test/data/cabal-exe/cabal.project
+++ b/test/data/cabal-exe/cabal.project
@@ -1,0 +1,1 @@
+packages: ./a

--- a/test/data/cabal-exe/hie.yaml
+++ b/test/data/cabal-exe/hie.yaml
@@ -1,0 +1,3 @@
+cradle:
+  cabal:
+    component: "exe:a"

--- a/test/exe/Main.hs
+++ b/test/exe/Main.hs
@@ -3270,7 +3270,7 @@ ignoreFatalWarning = testCase "ignore-fatal-warning" $ runWithExtraFiles "ignore
     expectNoMoreDiagnostics 5
 
 simpleSubDirectoryTest :: TestTree
-simpleSubDirectoryTest = expectFailBecause "File Targets are not normalised" $
+simpleSubDirectoryTest =
   testCase "simple-subdirectory" $ runWithExtraFiles "cabal-exe" $ \dir -> do
     let mainPath = dir </> "a/src/Main.hs"
     mainSource <- liftIO $ readFileUtf8 mainPath

--- a/test/exe/Main.hs
+++ b/test/exe/Main.hs
@@ -3192,6 +3192,7 @@ cradleTests = testGroup "cradle"
     ,testGroup "ignore-fatal" [ignoreFatalWarning]
     ,testGroup "loading" [loadCradleOnlyonce]
     ,testGroup "multi"   [simpleMultiTest, simpleMultiTest2]
+    ,testGroup "sub-directory"   [simpleSubDirectoryTest]
     ]
 
 loadCradleOnlyonce :: TestTree
@@ -3267,6 +3268,17 @@ ignoreFatalWarning = testCase "ignore-fatal-warning" $ runWithExtraFiles "ignore
     src <- liftIO $ readFileUtf8 srcPath
     _ <- createDoc srcPath "haskell" src
     expectNoMoreDiagnostics 5
+
+simpleSubDirectoryTest :: TestTree
+simpleSubDirectoryTest = expectFailBecause "File Targets are not normalised" $
+  testCase "simple-subdirectory" $ runWithExtraFiles "cabal-exe" $ \dir -> do
+    let mainPath = dir </> "a/src/Main.hs"
+    mainSource <- liftIO $ readFileUtf8 mainPath
+    _mdoc <- createDoc mainPath "haskell" mainSource
+    expectDiagnosticsWithTags
+      [("a/src/Main.hs", [(DsWarning,(2,0), "Top-level binding", Nothing)]) -- So that we know P has been loaded
+      ]
+    expectNoMoreDiagnostics 0.5
 
 simpleMultiTest :: TestTree
 simpleMultiTest = testCase "simple-multi-test" $ runWithExtraFiles "multi" $ \dir -> do


### PR DESCRIPTION
The filetargets are not correctly absolute. The hie-bios API did not articulate it correctly. 

So, in certain cases, the following error is shown for file-targets in sub-directory:
```
/tmp/extra-dir-30793437515428/src/Main.hs: openBinaryFile: does not exist (No such file or directory)
```

Adds a test that this was the case and is now fixed.