### PR TITLE
Favor `lookupPathToId` over `pathToId`

### DIFF
--- a/src/Development/IDE/Core/FileStore.hs
+++ b/src/Development/IDE/Core/FileStore.hs
@@ -239,10 +239,12 @@ typecheckParentsAction nfp = do
     revs <- transitiveReverseDependencies nfp <$> useNoFile_ GetModuleGraph
     logger <- logger <$> getShakeExtras
     let log = L.logInfo logger . T.pack
-    liftIO $ do
-      (log $ "Typechecking reverse dependencies for" ++ show nfp ++ ": " ++ show revs)
-        `catch` \(e :: SomeException) -> log (show e)
-    () <$ uses GetModIface revs
+    case revs of
+      Nothing -> liftIO $ log $ "Could not identify reverse dependencies for " ++ show nfp
+      Just rs -> do
+        liftIO $ (log $ "Typechecking reverse dependencies for " ++ show nfp ++ ": " ++ show revs)
+          `catch` \(e :: SomeException) -> log (show e)
+        () <$ uses GetModIface rs
 
 -- | Note that some buffer somewhere has been modified, but don't say what.
 --   Only valid if the virtual file system was initialised by LSP, as that


### PR DESCRIPTION
Fixes #921.

Done: `transitiveReverseDependencies` and `immediateReverseDependencies` have been refactored to return `Maybe [...]`.

I haven't changed `reportImportCyclesRule` or `transitiveDeps` as they seem to be acquitted in https://github.com/haskell/ghcide/issues/921#issue-749520646, although I can't say that I personally understand the logic there.

TODO: Predictably these types changing has stirred up type errors elsewhere. Although there are obvious workarounds, I'm not familiar with the desired behavior for these call sites to propose just converting `Nothing` -> `[]`.

https://github.com/haskell/ghcide/blob/30a46e8a18263c7b76384b854f40b21e6e88f7ba/src/Development/IDE/Core/FileStore.hs#L245

I imagine this should error out if we fail to get the reverse dependencies? If so, what's the appropriate way to error out of the `Action` monad?

https://github.com/haskell/ghcide/blob/f4bfe9c103e34de1d61d28f459eddf9e87f5c712/src/Development/IDE/Core/Rules.hs#L913

I imagine that `needsCompilationRule` should never fail? I don't understand what's going on here.