### PR TITLE
Custom cradle loading

### DIFF
--- a/exe/Main.hs
+++ b/exe/Main.hs
@@ -31,7 +31,7 @@ import Development.IDE.Plugin
 import Development.IDE.Plugin.Completions as Completions
 import Development.IDE.Plugin.CodeAction as CodeAction
 import Development.IDE.Plugin.Test as Test
-import Development.IDE.Session
+import Development.IDE.Session (loadSession)
 import qualified Language.Haskell.LSP.Core as LSP
 import Language.Haskell.LSP.Messages
 import Language.Haskell.LSP.Types


### PR DESCRIPTION
When using ghcide as a library, it may be desirable to host the hie.yaml file
in a location other than the project root, or even avoid the file system altogether