### PR TITLE
Extend import list automatically

### DIFF
--- a/src/Development/IDE/Plugin/Completions.hs
+++ b/src/Development/IDE/Plugin/Completions.hs
@@ -76,7 +76,7 @@ produceCompletions = do
               res <- liftIO $ tcRnImportDecls env imps'
               case res of
                   (_, Just rdrEnv) -> do
-                      cdata <- liftIO $ cacheDataProducer env (ms_mod ms) rdrEnv imps' parsedDeps
+                      cdata <- liftIO $ cacheDataProducer env (ms_mod ms) rdrEnv imps parsedDeps
                       return ([], Just cdata)
                   (_diag, _) ->
                       return ([], Nothing)

--- a/src/Development/IDE/Plugin/Completions.hs
+++ b/src/Development/IDE/Plugin/Completions.hs
@@ -72,11 +72,10 @@ produceCompletions = do
             (Just (ms,imps), Just sess) -> do
               let env = hscEnv sess
               -- We do this to be able to provide completions of items that are not restricted to the explicit list
-              let imps' = map dropListFromImportDecl imps
-              res <- liftIO $ tcRnImportDecls env imps'
+              res <- liftIO $ tcRnImportDecls env (dropListFromImportDecl <$> imps)
               case res of
                   (_, Just rdrEnv) -> do
-                      cdata <- liftIO $ cacheDataProducer env (ms_mod ms) rdrEnv imps' parsedDeps
+                      cdata <- liftIO $ cacheDataProducer env (ms_mod ms) rdrEnv imps parsedDeps
                       return ([], Just cdata)
                   (_diag, _) ->
                       return ([], Nothing)

--- a/src/Development/IDE/Plugin/Completions/Logic.hs
+++ b/src/Development/IDE/Plugin/Completions/Logic.hs
@@ -269,7 +269,8 @@ extendImportList name lDecl = let
             new_start_pos = start_pos {_character = _character start_pos - 1}
             -- use to same start_pos to handle situation where we do not have latest edits due to caching of Rules
             new_range = Range new_start_pos new_start_pos
-            alpha = all isAlphaNum name
+            -- we cannot wrap mapM_ inside (mapM_) but we need to wrap (<$)
+            alpha = all isAlphaNum $ filter (\c -> c /= '_') name
             comma_sep = if List.null (unLoc x) then "" else ", "
             result = if alpha then comma_sep ++ name
                 else comma_sep ++ "(" ++ name ++ ")"

--- a/src/Development/IDE/Plugin/Completions/Logic.hs
+++ b/src/Development/IDE/Plugin/Completions/Logic.hs
@@ -287,8 +287,8 @@ cacheDataProducer packageState curMod rdrEnv limports deps = do
   let dflags = hsc_dflags packageState
       curModName = moduleName curMod
 
-      !importMap = Map.fromList [
-          (showGhc . getLoc $ imp, imp)
+      importMap = Map.fromList [
+          (getLoc imp, imp)
           | imp <- limports ]
 
       iDeclToModName :: ImportDecl name -> ModuleName
@@ -319,8 +319,7 @@ cacheDataProducer packageState curMod rdrEnv limports deps = do
           (, mempty) <$> toCompItem curMod curModName n Nothing
       getComplsForOne (GRE n _ False prov) =
         flip foldMapM (map is_decl prov) $ \spec -> do
-          let !src_span = showGhc . is_dloc $ spec
-          let !originalImportDecl = Map.lookup src_span importMap
+          let originalImportDecl = Map.lookup (is_dloc spec) importMap
           compItem <- toCompItem curMod (is_mod spec) n originalImportDecl
           let unqual
                 | is_qual spec = []

--- a/src/Development/IDE/Plugin/Completions/Logic.hs
+++ b/src/Development/IDE/Plugin/Completions/Logic.hs
@@ -279,7 +279,7 @@ extendImportList name lDecl = let
                 else comma_sep ++ "(" ++ name ++ ")"
             in Just [TextEdit new_range (T.pack result)]
           | otherwise -> Nothing
-        otherwise -> Nothing  -- hiding import list and no list
+        Nothing -> Nothing  -- hiding import list and no list
     f _ _ = Nothing
     src_span = srcSpanToRange . getLoc $ lDecl
     in f src_span . unLoc $ lDecl

--- a/src/Development/IDE/Plugin/Completions/Logic.hs
+++ b/src/Development/IDE/Plugin/Completions/Logic.hs
@@ -197,7 +197,7 @@ mkNameCompItem origName origMod thingType isInfix docs !imp = CI{..}
     typeText
           | Just t <- thingType = Just . stripForall $ T.pack (showGhc t)
           | otherwise = Nothing
-    additionalTextEdits = (\x -> extendImports x (showGhc origName)) =<< imp
+    additionalTextEdits =  imp >>= extendImportList (showGhc origName)
 
     stripForall :: T.Text -> T.Text
     stripForall t
@@ -259,8 +259,8 @@ mkPragmaCompl label insertText =
     Nothing Nothing Nothing Nothing Nothing (Just insertText) (Just Snippet)
     Nothing Nothing Nothing Nothing Nothing
 
-extendImports :: LImportDecl GhcPs -> String -> Maybe [TextEdit]
-extendImports lDecl name = let
+extendImportList :: String -> LImportDecl GhcPs -> Maybe [TextEdit]
+extendImportList name lDecl = let
     f (Just range) ImportDecl {ideclHiding} = case ideclHiding of
         Just (False, x) -> let
             already_defined = Set.member name (Set.fromList [show y| y <- unLoc x])

--- a/src/Development/IDE/Plugin/Completions/Logic.hs
+++ b/src/Development/IDE/Plugin/Completions/Logic.hs
@@ -420,8 +420,6 @@ localCompletionsForParsedModule pm@ParsedModule{pm_parsed_source = L _ HsModule{
 
     thisModName = ppr hsmodName
 
---recordCompls = localRecordSnippetProducer pm thisModName
-
 findRecordCompl :: ParsedModule -> T.Text -> TyClDecl GhcPs -> [CompItem]
 findRecordCompl pmod mn DataDecl {tcdLName, tcdDataDefn} = result
     where

--- a/src/Development/IDE/Plugin/Completions/Logic.hs
+++ b/src/Development/IDE/Plugin/Completions/Logic.hs
@@ -174,7 +174,7 @@ mkNameCompItem origName origMod thingType isInfix docs = CI{..}
     typeText
           | Just t <- thingType = Just . stripForall $ T.pack (showGhc t)
           | otherwise = Nothing
-
+    additionalTextEdit = Nothing
 
     stripForall :: T.Text -> T.Text
     stripForall t
@@ -360,7 +360,7 @@ localCompletionsForParsedModule pm@ParsedModule{pm_parsed_source = L _ HsModule{
         ]
 
     mkComp n ctyp ty =
-        CI ctyp pn (Right thisModName) ty pn Nothing doc (ctyp `elem` [CiStruct, CiClass])
+        CI ctyp pn (Right thisModName) ty pn Nothing doc (ctyp `elem` [CiStruct, CiClass]) Nothing
       where
         pn = ppr n
         doc = SpanDocText (getDocumentation [pm] n) (SpanDocUris Nothing Nothing)
@@ -465,7 +465,7 @@ getCompletions ideOpts CC { allModNamesAsNS, unqualCompls, qualCompls, importabl
           endLoc = upperRange oldPos
           localCompls = map (uncurry localBindsToCompItem) $ getFuzzyScope localBindings startLoc endLoc
           localBindsToCompItem :: Name -> Maybe Type -> CompItem
-          localBindsToCompItem name typ = CI ctyp pn thisModName ty pn Nothing emptySpanDoc (not $ isValOcc occ)
+          localBindsToCompItem name typ = CI ctyp pn thisModName ty pn Nothing emptySpanDoc (not $ isValOcc occ) Nothing
             where
               occ = nameOccName name
               ctyp = occNameToComKind Nothing occ
@@ -674,6 +674,7 @@ mkRecordSnippetCompItem ctxStr compl mn docs = r
           , isInfix = Nothing
           , docs = docs
           , isTypeCompl = False
+          , additionalTextEdits = Nothing
           }
 
       placeholder_pairs = zip compl ([1..]::[Int])

--- a/src/Development/IDE/Plugin/Completions/Logic.hs
+++ b/src/Development/IDE/Plugin/Completions/Logic.hs
@@ -267,15 +267,18 @@ extendImportList name lDecl = let
           -> let
             start_pos = _end range
             new_start_pos = start_pos {_character = _character start_pos - 1}
-            line = _line . _end $ range
-            char = (_character . _end $ range) + 3 + length name
-            end_pos = Position line char
-            new_range = Range new_start_pos end_pos
+            --line = _line . _end $ range
+            --char = (_character . _end $ range) + 3 + length name
+            --end_pos = Position line char
+            --end_pos = new_start_pos -- {_character = _character new_start_pos}
+            -- use to same start_pos to handle situation where we do not have latest edits due to caching of Rules
+            new_range = Range new_start_pos new_start_pos
             alpha = all isAlphaNum name
-            result = if alpha then ", " ++ name ++ ")"
-                else ", (" ++ name ++ "))"
+            result = if alpha then ", " ++ name
+                else ", (" ++ name ++ ")"
             in Just [TextEdit new_range (T.pack result)]
           | otherwise -> Nothing
+        otherwise -> Nothing  -- hiding import list and no list
     f _ _ = Nothing
     src_span = srcSpanToRange . getLoc $ lDecl
     in f src_span . unLoc $ lDecl

--- a/src/Development/IDE/Plugin/Completions/Logic.hs
+++ b/src/Development/IDE/Plugin/Completions/Logic.hs
@@ -1,6 +1,9 @@
 {-# LANGUAGE CPP #-}
 
 #include "ghc-api-version.h"
+#if MIN_GHC_API_VERSION (8,8,4)
+{-# LANGUAGE GADTs#-}
+#endif
 -- Mostly taken from "haskell-ide-engine"
 module Development.IDE.Plugin.Completions.Logic (
   CachedCompletions

--- a/src/Development/IDE/Plugin/Completions/Logic.hs
+++ b/src/Development/IDE/Plugin/Completions/Logic.hs
@@ -197,7 +197,7 @@ mkNameCompItem origName origMod thingType isInfix docs !imp = CI{..}
     typeText
           | Just t <- thingType = Just . stripForall $ T.pack (showGhc t)
           | otherwise = Nothing
-    additionalTextEdits = maybe Nothing (\x -> extendImports x (showGhc origName)) imp
+    additionalTextEdits = (\x -> extendImports x (showGhc origName)) =<< imp
 
     stripForall :: T.Text -> T.Text
     stripForall t
@@ -276,7 +276,7 @@ extendImports lDecl name = let
             in
                 if already_defined
                 then Nothing
-                else Just $ [TextEdit new_range (T.pack result)]
+                else Just [TextEdit new_range (T.pack result)]
         _ -> Nothing
     f _ _ = Nothing
     src_span = srcSpanToRange . getLoc $ lDecl
@@ -322,9 +322,6 @@ cacheDataProducer packageState curMod rdrEnv limports deps = do
         flip foldMapM (map is_decl prov) $ \spec -> do
           let !src_span = showGhc . is_dloc $ spec
           let !originalImportDecl = Map.lookup src_span importMap
-          putStrLn "----building srcp span"
-          putStrLn $ show originalImportDecl
-          putStrLn "----print origin import decl"
           compItem <- toCompItem curMod (is_mod spec) n originalImportDecl
           let unqual
                 | is_qual spec = []

--- a/src/Development/IDE/Plugin/Completions/Logic.hs
+++ b/src/Development/IDE/Plugin/Completions/Logic.hs
@@ -267,10 +267,6 @@ extendImportList name lDecl = let
           -> let
             start_pos = _end range
             new_start_pos = start_pos {_character = _character start_pos - 1}
-            --line = _line . _end $ range
-            --char = (_character . _end $ range) + 3 + length name
-            --end_pos = Position line char
-            --end_pos = new_start_pos -- {_character = _character new_start_pos}
             -- use to same start_pos to handle situation where we do not have latest edits due to caching of Rules
             new_range = Range new_start_pos new_start_pos
             alpha = all isAlphaNum name

--- a/src/Development/IDE/Plugin/Completions/Logic.hs
+++ b/src/Development/IDE/Plugin/Completions/Logic.hs
@@ -276,7 +276,7 @@ extendImportList name lDecl = let
                 else comma_sep ++ "(" ++ name ++ ")"
             in Just [TextEdit new_range (T.pack result)]
           | otherwise -> Nothing
-        Nothing -> Nothing  -- hiding import list and no list
+        _ -> Nothing  -- hiding import list and no list
     f _ _ = Nothing
     src_span = srcSpanToRange . getLoc $ lDecl
     in f src_span . unLoc $ lDecl

--- a/src/Development/IDE/Plugin/Completions/Logic.hs
+++ b/src/Development/IDE/Plugin/Completions/Logic.hs
@@ -271,9 +271,8 @@ extendImportList name lDecl = let
             new_range = Range new_start_pos new_start_pos
             -- we cannot wrap mapM_ inside (mapM_) but we need to wrap (<$)
             alpha = all isAlphaNum $ filter (\c -> c /= '_') name
-            comma_sep = if List.null (unLoc x) then "" else ", "
-            result = if alpha then comma_sep ++ name
-                else comma_sep ++ "(" ++ name ++ ")"
+            result = if alpha then name ++ ", "
+                else "(" ++ name ++ "), "
             in Just [TextEdit new_range (T.pack result)]
           | otherwise -> Nothing
         _ -> Nothing  -- hiding import list and no list

--- a/src/Development/IDE/Plugin/Completions/Logic.hs
+++ b/src/Development/IDE/Plugin/Completions/Logic.hs
@@ -274,8 +274,9 @@ extendImportList name lDecl = let
             -- use to same start_pos to handle situation where we do not have latest edits due to caching of Rules
             new_range = Range new_start_pos new_start_pos
             alpha = all isAlphaNum name
-            result = if alpha then ", " ++ name
-                else ", (" ++ name ++ ")"
+            comma_sep = if List.null (unLoc x) then "" else ", "
+            result = if alpha then comma_sep ++ name
+                else comma_sep ++ "(" ++ name ++ ")"
             in Just [TextEdit new_range (T.pack result)]
           | otherwise -> Nothing
         otherwise -> Nothing  -- hiding import list and no list

--- a/src/Development/IDE/Plugin/Completions/Logic.hs
+++ b/src/Development/IDE/Plugin/Completions/Logic.hs
@@ -197,7 +197,7 @@ mkNameCompItem origName origMod thingType isInfix docs !imp = CI{..}
     typeText
           | Just t <- thingType = Just . stripForall $ T.pack (showGhc t)
           | otherwise = Nothing
-    additionalTextEdit = Nothing
+    additionalTextEdits = maybe Nothing (\x -> extendImports x (showGhc origName)) imp
 
     stripForall :: T.Text -> T.Text
     stripForall t

--- a/src/Development/IDE/Plugin/Completions/Types.hs
+++ b/src/Development/IDE/Plugin/Completions/Types.hs
@@ -8,7 +8,7 @@ import qualified Data.Text as T
 import SrcLoc
 
 import Development.IDE.Spans.Common
-import Language.Haskell.LSP.Types (CompletionItemKind)
+import Language.Haskell.LSP.Types (TextEdit, CompletionItemKind)
 
 -- From haskell-ide-engine/src/Haskell/Ide/Engine/LSP/Completions.hs
 
@@ -25,6 +25,7 @@ data CompItem = CI
                                    -- in the context of an infix notation.
   , docs         :: SpanDoc        -- ^ Available documentation.
   , isTypeCompl  :: Bool
+  , additionalTextEdits :: Maybe [TextEdit]
   }
   deriving (Eq, Show)
 

--- a/test/exe/Main.hs
+++ b/test/exe/Main.hs
@@ -2877,14 +2877,14 @@ nonLocalCompletionTests =
        "module A where", "import Control.Monad (msum)", "f = joi"]
       (Position 3 6)
       [("join", CiFunction, "join ${1:m (m a)}", False, False,
-        Just (List [TextEdit {_range = Range {_start = Position {_line = 2, _character = 26}, _end = Position {_line = 2, _character = 34}}, _newText = ", join)"}]))],
+        Just (List [TextEdit {_range = Range {_start = Position {_line = 2, _character = 26}, _end = Position {_line = 2, _character = 26}}, _newText = ", join"}]))],
     completionTest
       "show imports not in list - multi-line"
       ["{-# LANGUAGE NoImplicitPrelude #-}",
        "module A where", "import Control.Monad (\n    msum)", "f = joi"]
       (Position 4 6)
       [("join", CiFunction, "join ${1:m (m a)}", False, False,
-        Just (List [TextEdit {_range = Range {_start = Position {_line = 3, _character = 8}, _end = Position {_line = 3, _character = 16}}, _newText = ", join)"}]))],
+        Just (List [TextEdit {_range = Range {_start = Position {_line = 3, _character = 8}, _end = Position {_line = 3, _character = 8}}, _newText = ", join"}]))],
     completionTest
        "dont show hidden items"
        [ "{-# LANGUAGE NoImplicitPrelude #-}",

--- a/test/exe/Main.hs
+++ b/test/exe/Main.hs
@@ -2912,10 +2912,12 @@ nonLocalCompletionTests =
       "record snippet on import"
       ["module A where", "import Text.Printf (FormatParse(FormatParse))", "FormatParse"]
       (Position 2 10)
-      [("FormatParse", CiStruct, "FormatParse ", False, False, Nothing),
-       ("FormatParse", CiConstructor, "FormatParse ${1:String} ${2:Char} ${3:String}", False, False, Nothing),
-       ("FormatParse", CiSnippet,
-           "FormatParse {fpModifiers=${1:_fpModifiers}, fpChar=${2:_fpChar}, fpRest=${3:_fpRest}}", False, False, Nothing)
+      [("FormatParse", CiStruct, "FormatParse ", False, False,
+       Just (List [TextEdit {_range = Range {_start = Position {_line = 1, _character = 44}, _end = Position {_line = 1, _character = 44}}, _newText = "FormatParse, "}])),
+       ("FormatParse", CiConstructor, "FormatParse ${1:String} ${2:Char} ${3:String}", False, False,
+       Just (List [TextEdit {_range = Range {_start = Position {_line = 1, _character = 44}, _end = Position {_line = 1, _character = 44}}, _newText = "FormatParse, "}])),
+       ("FormatParse", CiSnippet, "FormatParse {fpModifiers=${1:_fpModifiers}, fpChar=${2:_fpChar}, fpRest=${3:_fpRest}}", False, False,
+       Just (List [TextEdit {_range = Range {_start = Position {_line = 1, _character = 44}, _end = Position {_line = 1, _character = 44}}, _newText = "FormatParse, "}]))
       ]
   ]
 

--- a/test/exe/Main.hs
+++ b/test/exe/Main.hs
@@ -2886,6 +2886,13 @@ nonLocalCompletionTests =
       [("join", CiFunction, "join ${1:m (m a)}", False, False,
         Just (List [TextEdit {_range = Range {_start = Position {_line = 3, _character = 8}, _end = Position {_line = 3, _character = 8}}, _newText = ", join"}]))],
     completionTest
+      "show imports not in list - initial empty list"
+      ["{-# LANGUAGE NoImplicitPrelude #-}",
+       "module A where", "import qualified Control.Monad as M ()", "f = M.joi"]
+      (Position 3 10)
+      [("join", CiFunction, "join ${1:m (m a)}", False, False,
+        Just (List [TextEdit {_range = Range {_start = Position {_line = 2, _character = 37}, _end = Position {_line = 2, _character = 37}}, _newText = "join"}]))],
+    completionTest
        "dont show hidden items"
        [ "{-# LANGUAGE NoImplicitPrelude #-}",
          "module A where",

--- a/test/exe/Main.hs
+++ b/test/exe/Main.hs
@@ -2717,7 +2717,7 @@ completionTests
     , testGroup "other" otherCompletionTests
     ]
 
-completionTest :: String -> [T.Text] -> Position -> [(T.Text, CompletionItemKind, T.Text, Bool, Bool)] -> TestTree
+completionTest :: String -> [T.Text] -> Position -> [(T.Text, CompletionItemKind, T.Text, Bool, Bool, Maybe (List TextEdit))] -> TestTree
 completionTest name src pos expected = testSessionWait name $ do
     docId <- createDoc "A.hs" "haskell" (T.unlines src)
     _ <- waitForDiagnostics
@@ -2725,10 +2725,8 @@ completionTest name src pos expected = testSessionWait name $ do
     let compls' = [ (_label, _kind, _insertText, _additionalTextEdits) | CompletionItem{..} <- compls]
     liftIO $ do
         let emptyToMaybe x = if T.null x then Nothing else Just x
-        --qliftIO $ putStrLn "-----------additional Edits-----"
-        --liftIO $ print . show $ compls'
-        compls' @?= [ (l, Just k, emptyToMaybe t, Nothing) | (l,k,t,_,_) <- expected]
-        forM_ (zip compls expected) $ \(CompletionItem{..}, (_,_,_,expectedSig, expectedDocs)) -> do
+        compls' @?= [ (l, Just k, emptyToMaybe t, at) | (l,k,t,_,_,at) <- expected]
+        forM_ (zip compls expected) $ \(CompletionItem{..}, (_,_,_,expectedSig, expectedDocs, _)) -> do
             when expectedSig $
                 assertBool ("Missing type signature: " <> T.unpack _label) (isJust _detail)
             when expectedDocs $
@@ -2740,43 +2738,43 @@ topLevelCompletionTests = [
         "variable"
         ["bar = xx", "-- | haddock", "xxx :: ()", "xxx = ()", "-- | haddock", "data Xxx = XxxCon"]
         (Position 0 8)
-        [("xxx", CiFunction, "xxx", True, True),
-         ("XxxCon", CiConstructor, "XxxCon", False, True)
+        [("xxx", CiFunction, "xxx", True, True, Nothing),
+         ("XxxCon", CiConstructor, "XxxCon", False, True, Nothing)
         ],
     completionTest
         "constructor"
         ["bar = xx", "-- | haddock", "xxx :: ()", "xxx = ()", "-- | haddock", "data Xxx = XxxCon"]
         (Position 0 8)
-        [("xxx", CiFunction, "xxx", True, True),
-         ("XxxCon", CiConstructor, "XxxCon", False, True)
+        [("xxx", CiFunction, "xxx", True, True, Nothing),
+         ("XxxCon", CiConstructor, "XxxCon", False, True, Nothing)
         ],
     completionTest
         "class method"
         ["bar = xx", "class Xxx a where", "-- | haddock", "xxx :: ()", "xxx = ()"]
         (Position 0 8)
-        [("xxx", CiFunction, "xxx", True, True)],
+        [("xxx", CiFunction, "xxx", True, True, Nothing)],
     completionTest
         "type"
         ["bar :: Xx", "xxx = ()", "-- | haddock", "data Xxx = XxxCon"]
         (Position 0 9)
-        [("Xxx", CiStruct, "Xxx", False, True)],
+        [("Xxx", CiStruct, "Xxx", False, True, Nothing)],
     completionTest
         "class"
         ["bar :: Xx", "xxx = ()", "-- | haddock", "class Xxx a"]
         (Position 0 9)
-        [("Xxx", CiClass, "Xxx", False, True)],
+        [("Xxx", CiClass, "Xxx", False, True, Nothing)],
     completionTest
         "records"
         ["data Person = Person { _personName:: String, _personAge:: Int}", "bar = Person { _pers }" ]
         (Position 1 19)
-        [("_personName", CiFunction, "_personName", False, True),
-         ("_personAge", CiFunction, "_personAge", False, True)],
+        [("_personName", CiFunction, "_personName", False, True, Nothing),
+         ("_personAge", CiFunction, "_personAge", False, True, Nothing)],
     completionTest
         "recordsConstructor"
         ["data XxRecord = XyRecord { x:: String, y:: Int}", "bar = Xy" ]
         (Position 1 19)
-        [("XyRecord", CiConstructor, "XyRecord", False, True),
-         ("XyRecord", CiSnippet, "XyRecord {x=${1:_x}, y=${2:_y}}", False, True)]
+        [("XyRecord", CiConstructor, "XyRecord", False, True, Nothing),
+         ("XyRecord", CiSnippet, "XyRecord {x=${1:_x}, y=${2:_y}}", False, True, Nothing)]
     ]
 
 localCompletionTests :: [TestTree]
@@ -2785,8 +2783,8 @@ localCompletionTests = [
         "argument"
         ["bar (Just abcdef) abcdefg = abcd"]
         (Position 0 32)
-        [("abcdef", CiFunction, "abcdef", True, False),
-         ("abcdefg", CiFunction , "abcdefg", True, False)
+        [("abcdef", CiFunction, "abcdef", True, False, Nothing),
+         ("abcdefg", CiFunction , "abcdefg", True, False, Nothing)
         ],
     completionTest
         "let"
@@ -2795,8 +2793,8 @@ localCompletionTests = [
         ,"        in abcd"
         ]
         (Position 2 15)
-        [("abcdef", CiFunction, "abcdef", True, False),
-         ("abcdefg", CiFunction , "abcdefg", True, False)
+        [("abcdef", CiFunction, "abcdef", True, False, Nothing),
+         ("abcdefg", CiFunction , "abcdefg", True, False, Nothing)
         ],
     completionTest
         "where"
@@ -2805,8 +2803,8 @@ localCompletionTests = [
         ,"        abcdefg = let abcd = undefined in undefined"
         ]
         (Position 0 10)
-        [("abcdef", CiFunction, "abcdef", True, False),
-         ("abcdefg", CiFunction , "abcdefg", True, False)
+        [("abcdef", CiFunction, "abcdef", True, False, Nothing),
+         ("abcdefg", CiFunction , "abcdefg", True, False, Nothing)
         ],
     completionTest
         "do/1"
@@ -2817,7 +2815,7 @@ localCompletionTests = [
         ,"  pure ()"
         ]
         (Position 2 6)
-        [("abcdef", CiFunction, "abcdef", True, False)
+        [("abcdef", CiFunction, "abcdef", True, False, Nothing)
         ],
     completionTest
         "do/2"
@@ -2831,12 +2829,12 @@ localCompletionTests = [
         ,"    abcdefghij = undefined"
         ]
         (Position 5 8)
-        [("abcde", CiFunction, "abcde", True, False)
-        ,("abcdefghij", CiFunction, "abcdefghij", True, False)
-        ,("abcdef", CiFunction, "abcdef", True, False)
-        ,("abcdefg", CiFunction, "abcdefg", True, False)
-        ,("abcdefgh", CiFunction, "abcdefgh", True, False)
-        ,("abcdefghi", CiFunction, "abcdefghi", True, False)
+        [("abcde", CiFunction, "abcde", True, False, Nothing)
+        ,("abcdefghij", CiFunction, "abcdefghij", True, False, Nothing)
+        ,("abcdef", CiFunction, "abcdef", True, False, Nothing)
+        ,("abcdefg", CiFunction, "abcdefg", True, False, Nothing)
+        ,("abcdefgh", CiFunction, "abcdefgh", True, False, Nothing)
+        ,("abcdefghi", CiFunction, "abcdefghi", True, False, Nothing)
         ]
     ]
 
@@ -2846,58 +2844,47 @@ nonLocalCompletionTests =
       "variable"
       ["module A where", "f = hea"]
       (Position 1 7)
-      [("head", CiFunction, "head ${1:[a]}", True, True)],
+      [("head", CiFunction, "head ${1:[a]}", True, True, Nothing)],
     completionTest
       "constructor"
       ["module A where", "f = Tru"]
       (Position 1 7)
-      [ ("True", CiConstructor, "True ", True, True),
-        ("truncate", CiFunction, "truncate ${1:a}", True, True)
+      [ ("True", CiConstructor, "True ", True, True, Nothing),
+        ("truncate", CiFunction, "truncate ${1:a}", True, True, Nothing)
       ],
     completionTest
       "type"
       ["{-# OPTIONS_GHC -Wall #-}", "module A () where", "f :: Bo", "f = True"]
       (Position 2 7)
-      [ ("Bounded", CiClass, "Bounded ${1:*}", True, True),
-        ("Bool", CiStruct, "Bool ", True, True)
+      [ ("Bounded", CiClass, "Bounded ${1:*}", True, True, Nothing),
+        ("Bool", CiStruct, "Bool ", True, True, Nothing)
       ],
     completionTest
       "qualified"
       ["{-# OPTIONS_GHC -Wunused-binds #-}", "module A () where", "f = Prelude.hea"]
       (Position 2 15)
-      [ ("head", CiFunction, "head ${1:[a]}", True, True)
+      [ ("head", CiFunction, "head ${1:[a]}", True, True, Nothing)
       ],
     completionTest
       "duplicate import"
       ["module A where", "import Data.List", "import Data.List", "f = perm"]
       (Position 3 8)
-      [ ("permutations", CiFunction, "permutations ${1:[a]}", False, False)
+      [ ("permutations", CiFunction, "permutations ${1:[a]}", False, False, Nothing)
       ],
     completionTest
       "show imports not in list - simple"
       ["{-# LANGUAGE NoImplicitPrelude #-}",
        "module A where", "import Control.Monad (msum)", "f = joi"]
       (Position 3 6)
-      [("join", CiFunction, "join ${1:m (m a)}", False, False)],
+      [("join", CiFunction, "join ${1:m (m a)}", False, False,
+        Just (List [TextEdit {_range = Range {_start = Position {_line = 2, _character = 26}, _end = Position {_line = 2, _character = 34}}, _newText = ", join)"}]))],
     completionTest
-      "show imports not in list - pre qualified"
+      "show imports not in list - multi-line"
       ["{-# LANGUAGE NoImplicitPrelude #-}",
-       "module A where", "import qualified Control.Monad (msum)", "f = Control.Monad.joi"]
-      (Position 3 20)
-      [("join", CiFunction, "join ${1:m (m a)}", False, False)],
-    completionTest
-      "show imports not in list - post qualified"
-      ["{-# LANGUAGE NoImplicitPrelude #-}",
-       "{-# LANGUAGE ImportQualifiedPost #-}",
-       "module A where", "import Control.Monad qualified (msum)", "f = Control.Monad.joi"]
-      (Position 4 20)
-      [("join", CiFunction, "join ${1:m (m a)}", False, False)],
-    completionTest
-      "show imports not in list - qualified string"
-      ["{-# LANGUAGE NoImplicitPrelude #-}",
-       "module A where", "import qualified Control.Monad as Foo (msum, join)", "f = Foo.joi"]
-      (Position 3 10)
-      [("join", CiFunction, "join ${1:m (m a)}", False, False)],
+       "module A where", "import Control.Monad (\n    msum)", "f = joi"]
+      (Position 4 6)
+      [("join", CiFunction, "join ${1:m (m a)}", False, False,
+        Just (List [TextEdit {_range = Range {_start = Position {_line = 3, _character = 8}, _end = Position {_line = 3, _character = 16}}, _newText = ", join)"}]))],
     completionTest
        "dont show hidden items"
        [ "{-# LANGUAGE NoImplicitPrelude #-}",
@@ -2911,10 +2898,10 @@ nonLocalCompletionTests =
       "record snippet on import"
       ["module A where", "import Text.Printf (FormatParse(FormatParse))", "FormatParse"]
       (Position 2 10)
-      [("FormatParse", CiStruct, "FormatParse ", False, False),
-       ("FormatParse", CiConstructor, "FormatParse ${1:String} ${2:Char} ${3:String}", False, False),
+      [("FormatParse", CiStruct, "FormatParse ", False, False, Nothing),
+       ("FormatParse", CiConstructor, "FormatParse ${1:String} ${2:Char} ${3:String}", False, False, Nothing),
        ("FormatParse", CiSnippet,
-           "FormatParse {fpModifiers=${1:_fpModifiers}, fpChar=${2:_fpChar}, fpRest=${3:_fpRest}}", False, False)
+           "FormatParse {fpModifiers=${1:_fpModifiers}, fpChar=${2:_fpChar}, fpRest=${3:_fpRest}}", False, False, Nothing)
       ]
   ]
 
@@ -2924,7 +2911,7 @@ otherCompletionTests = [
       "keyword"
       ["module A where", "f = newty"]
       (Position 1 9)
-      [("newtype", CiKeyword, "", False, False)],
+      [("newtype", CiKeyword, "", False, False, Nothing)],
     completionTest
       "type context"
       [ "{-# OPTIONS_GHC -Wunused-binds #-}",
@@ -2936,7 +2923,7 @@ otherCompletionTests = [
       -- This should be sufficient to detect that we are in a
       -- type context and only show the completion to the type.
       (Position 3 11)
-      [("Integer", CiStruct, "Integer ", True, True)]
+      [("Integer", CiStruct, "Integer ", True, True, Nothing)]
   ]
 
 highlightTests :: TestTree

--- a/test/exe/Main.hs
+++ b/test/exe/Main.hs
@@ -2812,7 +2812,22 @@ nonLocalCompletionTests =
       ["module A where", "import Data.List", "import Data.List", "f = perm"]
       (Position 3 8)
       [ ("permutations", CiFunction, False, False)
-      ]
+      ],
+    completionTest
+      "show imports not in list but available in module"
+      ["{-# LANGUAGE NoImplicitPrelude #-}",
+       "module A where", "import Control.Monad (msum)", "f = joi"]
+      (Position 3 6)
+      [("join", CiFunction, False, False)],
+    completionTest
+       "dont show hidden items"
+       [ "{-# LANGUAGE NoImplicitPrelude #-}",
+         "module A where",
+         "import Control.Monad hiding (join)",
+         "f = joi"
+       ]
+       (Position 3 6)
+       []
   ]
 
 otherCompletionTests :: [TestTree]

--- a/test/exe/Main.hs
+++ b/test/exe/Main.hs
@@ -2877,28 +2877,28 @@ nonLocalCompletionTests =
        "module A where", "import Control.Monad (msum)", "f = joi"]
       (Position 3 6)
       [("join", CiFunction, "join ${1:m (m a)}", False, False,
-        Just (List [TextEdit {_range = Range {_start = Position {_line = 2, _character = 26}, _end = Position {_line = 2, _character = 26}}, _newText = ", join"}]))],
+        Just (List [TextEdit {_range = Range {_start = Position {_line = 2, _character = 26}, _end = Position {_line = 2, _character = 26}}, _newText = "join, "}]))],
     completionTest
       "show imports not in list - multi-line"
       ["{-# LANGUAGE NoImplicitPrelude #-}",
        "module A where", "import Control.Monad (\n    msum)", "f = joi"]
       (Position 4 6)
       [("join", CiFunction, "join ${1:m (m a)}", False, False,
-        Just (List [TextEdit {_range = Range {_start = Position {_line = 3, _character = 8}, _end = Position {_line = 3, _character = 8}}, _newText = ", join"}]))],
+        Just (List [TextEdit {_range = Range {_start = Position {_line = 3, _character = 8}, _end = Position {_line = 3, _character = 8}}, _newText = "join, "}]))],
     completionTest
       "show imports not in list - names with _"
       ["{-# LANGUAGE NoImplicitPrelude #-}",
        "module A where", "import qualified Control.Monad as M (msum)", "f = M.mapM_"]
       (Position 3 11)
       [("mapM_", CiFunction, "mapM_ ${1:a -> m b} ${2:t a}", False, False,
-        Just (List [TextEdit {_range = Range {_start = Position {_line = 2, _character = 41}, _end = Position {_line = 2, _character = 41}}, _newText = ", mapM_"}]))],
+        Just (List [TextEdit {_range = Range {_start = Position {_line = 2, _character = 41}, _end = Position {_line = 2, _character = 41}}, _newText = "mapM_, "}]))],
     completionTest
       "show imports not in list - initial empty list"
       ["{-# LANGUAGE NoImplicitPrelude #-}",
        "module A where", "import qualified Control.Monad as M ()", "f = M.joi"]
       (Position 3 10)
       [("join", CiFunction, "join ${1:m (m a)}", False, False,
-        Just (List [TextEdit {_range = Range {_start = Position {_line = 2, _character = 37}, _end = Position {_line = 2, _character = 37}}, _newText = "join"}]))],
+        Just (List [TextEdit {_range = Range {_start = Position {_line = 2, _character = 37}, _end = Position {_line = 2, _character = 37}}, _newText = "join, "}]))],
     completionTest
        "dont show hidden items"
        [ "{-# LANGUAGE NoImplicitPrelude #-}",

--- a/test/exe/Main.hs
+++ b/test/exe/Main.hs
@@ -2886,6 +2886,13 @@ nonLocalCompletionTests =
       [("join", CiFunction, "join ${1:m (m a)}", False, False,
         Just (List [TextEdit {_range = Range {_start = Position {_line = 3, _character = 8}, _end = Position {_line = 3, _character = 8}}, _newText = ", join"}]))],
     completionTest
+      "show imports not in list - names with _"
+      ["{-# LANGUAGE NoImplicitPrelude #-}",
+       "module A where", "import qualified Control.Monad as M (msum)", "f = M.mapM_"]
+      (Position 3 11)
+      [("mapM_", CiFunction, "mapM_ ${1:a -> m b} ${2:t a}", False, False,
+        Just (List [TextEdit {_range = Range {_start = Position {_line = 2, _character = 41}, _end = Position {_line = 2, _character = 41}}, _newText = ", mapM_"}]))],
+    completionTest
       "show imports not in list - initial empty list"
       ["{-# LANGUAGE NoImplicitPrelude #-}",
        "module A where", "import qualified Control.Monad as M ()", "f = M.joi"]


### PR DESCRIPTION
Address #576 requirement of automatically extending the import list.

Few points to address (and I would like some pointers on this)

 Simple working Demo
![completions_simple](https://user-images.githubusercontent.com/1274371/100632302-88dac080-32e1-11eb-9914-774e02265c08.gif)

Items to address:

- [x]  Multi-line edits handled, but may need post hlint step to align with other imports
```
import Control.Monad as M (
   join,
     msum)
```
This PR  adds the new item to the last item like this:

```
import Control.Monad as M (
   join,
     msum, mplus)
```
Demo: 
![completions_multi_line](https://user-images.githubusercontent.com/1274371/100632368-9728dc80-32e1-11eb-8e8e-3588f83e9587.gif)

- [x]  After edits, due to caching,  inserts might be duplicated. We need hlint to handle it.
