### PR TITLE
Use GADTs for all ghc versions in Development.IDE.Plugin.Completions.Logic

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,6 +1,6 @@
 name: Benchmark
 
-on: [push, pull_request]
+on: [pull_request]
 jobs:
   bench:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,6 +1,6 @@
 name: Nix
 
-on: [push, pull_request]
+on: [pull_request]
 jobs:
   nix:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,9 +8,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # build not tested ghc versions
+        # all versions to only build or test for non windows os's
+        # inclusions will modify the major ones to mark them as testables
         os: [macOS-latest, ubuntu-latest]
         ghc: ['8.10.2', '8.10.1', '8.8.4', '8.8.3', '8.8.2', '8.6.5', '8.6.4']
+        ghc-lib: [false]
         include:
           # one ghc-lib build
           - os: ubuntu-latest
@@ -87,7 +89,7 @@ jobs:
       run: cabal build || cabal build || cabal build
 
     - name: Test
+      if: ${{ !matrix.ghc-lib && matrix.test }}
       shell: bash
       # run the tests without parallelism to avoid running out of memory
       run: cabal test --test-options="-j1 --rerun-update" || cabal test --test-options="-j1 --rerun" || LSP_TEST_LOG_COLOR=0 LSP_TEST_LOG_MESSAGES=true LSP_TEST_LOG_STDERR=true cabal test --test-options="-j1 --rerun"
-      if: ${{ !matrix.ghc-lib}} && {{matrix.test}}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,13 +24,13 @@ jobs:
             ghc-lib: true
           # run the testsuite only once per ghc major version
           - os: [macOS-latest, ubuntu-latest, windows-latest]
-          - ghc: '8.10.2'
+            ghc: '8.10.2'
             test: true
           - os: [macOS-latest, ubuntu-latest, windows-latest]
-          - ghc: '8.8.4'
+            ghc: '8.8.4'
             test: true
           - os: [macOS-latest, ubuntu-latest, windows-latest]
-          - ghc: '8.6.5'
+            ghc: '8.6.5'
             test: true
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,10 +23,13 @@ jobs:
             ghc: '8.10.1'
             ghc-lib: true
           # run the testsuite only once per ghc major version
+          - os: [macOS-latest, ubuntu-latest, windows-latest]
           - ghc: '8.10.2'
             test: true
+          - os: [macOS-latest, ubuntu-latest, windows-latest]
           - ghc: '8.8.4'
             test: true
+          - os: [macOS-latest, ubuntu-latest, windows-latest]
           - ghc: '8.6.5'
             test: true
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,30 +8,45 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macOS-latest, ubuntu-latest, windows-latest]
+        # build not tested ghc versions
+        os: [macOS-latest, ubuntu-latest]
         ghc: ['8.10.2', '8.10.1', '8.8.4', '8.8.3', '8.8.2', '8.6.5', '8.6.4']
-        test: [false]
-        ghc-lib: [false]
-        exclude:
-          - os: windows-latest
-            ghc: '8.10.2' # broken due to https://gitlab.haskell.org/ghc/ghc/-/issues/18550
-          - os: windows-latest
-            ghc: '8.8.4' # also fails due to segfault :(
         include:
           # one ghc-lib build
           - os: ubuntu-latest
             ghc: '8.10.1'
             ghc-lib: true
-          # run the testsuite only once per ghc major version
-          - os: [macOS-latest, ubuntu-latest, windows-latest]
+          # only test supported ghc major versions
+          - os: macOS-latest
             ghc: '8.10.2'
             test: true
-          - os: [macOS-latest, ubuntu-latest, windows-latest]
+          - os: ubuntu-latest
+            ghc: '8.10.2'
+            test: true
+          # specific 8.10.2 version for windows and chocolatey
+          - os: windows-latest
+            ghc: '8.10.2.2'
+            test: true
+          - os: macOS-latest
             ghc: '8.8.4'
             test: true
-          - os: [macOS-latest, ubuntu-latest, windows-latest]
+          - os: ubuntu-latest
+            ghc: '8.8.4'
+            test: true
+          - os: macOS-latest
             ghc: '8.6.5'
             test: true
+          - os: ubuntu-latest
+            ghc: '8.6.5'
+            test: true
+          - os: windows-latest
+            ghc: '8.6.5'
+            test: true
+          # only build rest of supported ghc versions for windows
+          - os: windows-latest
+            ghc: '8.10.1'
+          - os: windows-latest
+            ghc: '8.6.4'
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: Testing
 
-on: [push, pull_request]
+on: [pull_request]
 jobs:
   test:
     timeout-minutes: 360

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [macOS-latest, ubuntu-latest, windows-latest]
-        ghc: ['8.10.2', '8.8.4', '8.6.5']
+        ghc: ['8.10.2', '8.10.1', '8.8.4', '8.8.3', '8.8.2', '8.6.5', '8.6.4']
+        test: [false]
         ghc-lib: [false]
         exclude:
           - os: windows-latest
@@ -17,11 +18,17 @@ jobs:
           - os: windows-latest
             ghc: '8.8.4' # also fails due to segfault :(
         include:
-          - os: windows-latest
-            ghc: '8.10.1'
+          # one ghc-lib build
           - os: ubuntu-latest
             ghc: '8.10.1'
             ghc-lib: true
+          # run the testsuite only once per ghc major version
+          - ghc: '8.10.2'
+            test: true
+          - ghc: '8.8.4'
+            test: true
+          - ghc: '8.6.5'
+            test: true
 
     steps:
     - uses: actions/checkout@v2
@@ -65,4 +72,4 @@ jobs:
       shell: bash
       # run the tests without parallelism to avoid running out of memory
       run: cabal test --test-options="-j1 --rerun-update" || cabal test --test-options="-j1 --rerun" || LSP_TEST_LOG_COLOR=0 LSP_TEST_LOG_MESSAGES=true LSP_TEST_LOG_STDERR=true cabal test --test-options="-j1 --rerun"
-      if: ${{ !matrix.ghc-lib}}
+      if: ${{ !matrix.ghc-lib}} && {{matrix.test}}

--- a/src/Development/IDE/Plugin/Completions/Logic.hs
+++ b/src/Development/IDE/Plugin/Completions/Logic.hs
@@ -1,9 +1,8 @@
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE GADTs#-}
 
 #include "ghc-api-version.h"
-#if MIN_GHC_API_VERSION (8,8,4)
-{-# LANGUAGE GADTs#-}
-#endif
+
 -- Mostly taken from "haskell-ide-engine"
 module Development.IDE.Plugin.Completions.Logic (
   CachedCompletions


### PR DESCRIPTION
* It fixes the build for ghc-8.8.3 and ghc-8.8.2 that was failing with:

```
Progress 166/173: ghcide ghcide > /root/build/ghcide/src/Development/IDE/Plugin/Completions/Logic.hs:267:5: error:
Progress 166/173: ghcide ghcide >     • Illegal equational constraint NoGhcTcPass pass
Progress 166/173: ghcide ghcide >                                     ~ NoGhcTcPass (NoGhcTcPass pass)
Progress 166/173: ghcide ghcide >       (Use GADTs or TypeFamilies to permit this)
Progress 166/173: ghcide ghcide >     • When checking the inferred type
Progress 166/173: ghcide ghcide >         f :: forall (pass :: Pass).
Progress 166/173: ghcide ghcide >              (Outputable.OutputableBndr
Progress 166/173: ghcide ghcide >                 (NameOrRdrName (IdP (GhcPass (NoGhcTcPass pass)))),
Progress 166/173: ghcide ghcide >               Outputable.OutputableBndr (IdP (GhcPass (NoGhcTcPass pass))),
Progress 166/173: ghcide ghcide >               Outputable.OutputableBndr (IdP (GhcPass pass)),
Progress 166/173: ghcide ghcide >               Outputable.OutputableBndr (NameOrRdrName (IdP (GhcPass pass))),
Progress 166/173: ghcide ghcide >               Outputable (XIPBinds (GhcPass pass)),
Progress 166/173: ghcide ghcide >               Outputable (XViaStrategy (GhcPass pass)),
Progress 166/173: ghcide ghcide >               Outputable (XIPBinds (GhcPass (NoGhcTcPass pass))),
Progress 166/173: ghcide ghcide >               Outputable (XViaStrategy (GhcPass (NoGhcTcPass pass))),
Progress 166/173: ghcide ghcide >               NoGhcTcPass pass ~ NoGhcTcPass (NoGhcTcPass pass)) =>
Progress 166/173: ghcide ghcide >              Maybe Range -> ImportDecl (GhcPass pass) -> Maybe [TextEdit]
Progress 166/173: ghcide ghcide >       In the expression:
Progress 166/173: ghcide ghcide >         let
Progress 166/173: ghcide ghcide >           f (Just range) ImportDecl {ideclHiding}
Progress 166/173: ghcide ghcide >             = case ideclHiding of
Progress 166/173: ghcide ghcide >                 Just (False, x)
Progress 166/173: ghcide ghcide >                   | Set.notMember name (Set.fromList ...) -> ...
Progress 166/173: ghcide ghcide >                   | otherwise -> ...
Progress 166/173: ghcide ghcide >                 _ -> ...
Progress 166/173: ghcide ghcide >           f _ _ = Nothing
Progress 166/173: ghcide ghcide >           src_span = srcSpanToRange . getLoc $ lDecl
Progress 166/173: ghcide ghcide >         in f src_span . unLoc $ lDecl
Progress 166/173: ghcide ghcide >       In an equation for ‘extendImportList’:
Progress 166/173: ghcide ghcide >           extendImportList name lDecl
Progress 166/173: ghcide ghcide >             = let
Progress 166/173: ghcide ghcide >                 f (Just range) ImportDecl {ideclHiding} = ...
Progress 166/173: ghcide ghcide >                 f _ _ = Nothing
Progress 166/173: ghcide ghcide >                 src_span = srcSpanToRange . getLoc $ lDecl
Progress 166/173: ghcide ghcide >               in f src_span . unLoc $ lDecl
Progress 166/173: ghcide ghcide >     |
Progress 166/173: ghcide ghcide > 267 |     f (Just range) ImportDecl {ideclHiding} = case ideclHiding of
Progress 166/173: ghcide ghcide >     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^...
Progress 166/173: ghcide ghcide > 
```

It unblocks the bump of ghcide in hls (and the incoming release): https://github.com/haskell/haskell-language-server/pull/658.
Will rebase #946 when it is ready