### PR TITLE
Deduplicate module not found diagnostics

### DIFF
--- a/exe/Main.hs
+++ b/exe/Main.hs
@@ -150,6 +150,8 @@ main = do
                     -- , optOTMemoryProfiling = IdeOTMemoryProfiling argsOTMemoryProfiling
                     , optTesting           = IdeTesting argsTesting
                     , optThreads           = argsThreads
+                    , optCheckParents      = NeverCheck
+                    , optCheckProject      = CheckProject False
                     }
             logLevel = if argsVerbose then minBound else Info
         ide <- initialise def mainRule (pure $ IdInt 0) (showEvent lock) dummyWithProg (const (const id)) (logger logLevel) debouncer options vfs

--- a/src/Development/IDE/Core/Rules.hs
+++ b/src/Development/IDE/Core/Rules.hs
@@ -553,9 +553,11 @@ getBindingsRule =
 getDocMapRule :: Rules ()
 getDocMapRule =
     define $ \GetDocMap file -> do
-      (tmrTypechecked -> tc) <- use_ TypeCheck file
-      (hscEnv -> hsc) <- use_ GhcSessionDeps file
-      (refMap -> rf) <- use_ GetHieAst file
+      -- Stale data for the scenario where a broken module has previously typechecked
+      -- but we never generated a DocMap for it
+      (tmrTypechecked -> tc, _) <- useWithStale_ TypeCheck file
+      (hscEnv -> hsc, _)        <- useWithStale_ GhcSessionDeps file
+      (refMap -> rf, _)         <- useWithStale_ GetHieAst file
 
 -- When possible, rely on the haddocks embedded in our interface files
 -- This creates problems on ghc-lib, see comment on 'getDocumentationTryGhc'

--- a/src/Development/IDE/Core/Shake.hs
+++ b/src/Development/IDE/Core/Shake.hs
@@ -830,7 +830,7 @@ defineEarlyCutoff
     :: IdeRule k v
     => (k -> NormalizedFilePath -> Action (Maybe BS.ByteString, IdeResult v))
     -> Rules ()
-defineEarlyCutoff op = addBuiltinRule noLint noIdentity $ \(Q (key, file)) (old :: Maybe BS.ByteString) mode -> otTracedAction key file $ do
+defineEarlyCutoff op = addBuiltinRule noLint noIdentity $ \(Q (key, file)) (old :: Maybe BS.ByteString) mode -> otTracedAction key file isSuccess $ do
     extras@ShakeExtras{state, inProgress} <- getShakeExtras
     -- don't do progress for GetFileExists, as there are lots of non-nodes for just that one key
     (if show key == "GetFileExists" then id else withProgressVar inProgress file) $ do
@@ -880,8 +880,9 @@ defineEarlyCutoff op = addBuiltinRule noLint noIdentity $ \(Q (key, file)) (old 
         -- least 1000 modifications.
         where f shift = modifyVar_ var $ \x -> evaluate $ HMap.insertWith (\_ x -> shift x) file (shift 0) x
 
-
-
+isSuccess :: RunResult (A v) -> Bool
+isSuccess (RunResult _ _ (A Failed)) = False
+isSuccess _ = True
 
 -- | Rule type, input file
 data QDisk k = QDisk k NormalizedFilePath

--- a/test/exe/Main.hs
+++ b/test/exe/Main.hs
@@ -323,8 +323,11 @@ diagnosticTests = testGroup "diagnostics"
             , "import {-# SOURCE #-} ModuleB"
             ]
       let contentB = T.unlines
-            [ "module ModuleB where"
+            [ "{-# OPTIONS -Wmissing-signatures#-}"
+            , "module ModuleB where"
             , "import ModuleA"
+            -- introduce an artificial diagnostic
+            , "foo = ()"
             ]
       let contentBboot = T.unlines
             [ "module ModuleB where"
@@ -332,7 +335,7 @@ diagnosticTests = testGroup "diagnostics"
       _ <- createDoc "ModuleA.hs" "haskell" contentA
       _ <- createDoc "ModuleB.hs" "haskell" contentB
       _ <- createDoc "ModuleB.hs-boot" "haskell" contentBboot
-      expectDiagnostics []
+      expectDiagnostics [("ModuleB.hs", [(DsWarning, (3,0), "Top-level binding")])]
   , testSessionWait "correct reference used with hs-boot" $ do
       let contentB = T.unlines
             [ "module ModuleB where"
@@ -347,7 +350,8 @@ diagnosticTests = testGroup "diagnostics"
             [ "module ModuleA where"
             ]
       let contentC = T.unlines
-            [ "module ModuleC where"
+            [ "{-# OPTIONS -Wmissing-signatures #-}"
+            , "module ModuleC where"
             , "import ModuleA"
             -- this reference will fail if it gets incorrectly
             -- resolved to the hs-boot file
@@ -357,7 +361,7 @@ diagnosticTests = testGroup "diagnostics"
       _ <- createDoc "ModuleA.hs" "haskell" contentA
       _ <- createDoc "ModuleA.hs-boot" "haskell" contentAboot
       _ <- createDoc "ModuleC.hs" "haskell" contentC
-      expectDiagnostics []
+      expectDiagnostics [("ModuleC.hs", [(DsWarning, (3,0), "Top-level binding")])]
   , testSessionWait "redundant import" $ do
       let contentA = T.unlines ["module ModuleA where"]
       let contentB = T.unlines
@@ -375,13 +379,15 @@ diagnosticTests = testGroup "diagnostics"
   , testSessionWait "redundant import even without warning" $ do
       let contentA = T.unlines ["module ModuleA where"]
       let contentB = T.unlines
-            [ "{-# OPTIONS_GHC -Wno-unused-imports #-}"
+            [ "{-# OPTIONS_GHC -Wno-unused-imports -Wmissing-signatures #-}"
             , "module ModuleB where"
             , "import ModuleA"
+            -- introduce an artificial warning for testing purposes
+            , "foo = ()"
             ]
       _ <- createDoc "ModuleA.hs" "haskell" contentA
       _ <- createDoc "ModuleB.hs" "haskell" contentB
-      expectDiagnostics []
+      expectDiagnostics [("ModuleB.hs", [(DsWarning, (3,0), "Top-level binding")])]
   , testSessionWait "package imports" $ do
       let thisDataListContent = T.unlines
             [ "module Data.List where"


### PR DESCRIPTION
Reworked version of #943. The root problem was in the use of stale data in rules - after adding a missing import the `GetDependencies` rule would fail, but `TypeCheck` would go ahead anyway with the last successful result of `GetDependencies` and generate a missing module diagnostic which duplicates the one already generated by `GetDependencies`.

In general it seems a very bad idea to use stale data in core rules, if only because it makes it very difficult to reason about diagnostics. I have removed all other uses I've seen. 

While I was debugging this with the command line driver, I found the default options to check all targets very noisy, and I changed the defaults (for the command line driver only). Moreover, I added tracing of rule failures.

Fixes haskell/haskell-language-server#630