### PR TITLE
Prepare release 0.6.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 0.6.0.2 (2020-12-26)
+* Fix disappearing diagnostics bug (#959) - (Pepe Iborra)
+* Use qualified module name from diagnostics in suggestNewImport (#945) - (Potato Hatsue)
+* Disable auto extend import snippets in completions (these need a bit more work)
+
 ### 0.6.0.1 (2020-12-13)
 * Fix build with GHC 8.8.2 and 8.8.3 - (Javier Neira)
 * Update old URLs still pointing to digital-asset - (Jan Hrcek)

--- a/ghcide.cabal
+++ b/ghcide.cabal
@@ -2,7 +2,7 @@ cabal-version:      1.20
 build-type:         Simple
 category:           Development
 name:               ghcide
-version:            0.6.0.1
+version:            0.6.0.2
 license:            Apache-2.0
 license-file:       LICENSE
 author:             Digital Asset and Ghcide contributors

--- a/src/Development/IDE/Plugin/Completions/Logic.hs
+++ b/src/Development/IDE/Plugin/Completions/Logic.hs
@@ -287,10 +287,6 @@ cacheDataProducer packageState curMod rdrEnv limports deps = do
   let dflags = hsc_dflags packageState
       curModName = moduleName curMod
 
-      importMap = Map.fromList [
-          (getLoc imp, imp)
-          | imp <- limports ]
-
       iDeclToModName :: ImportDecl name -> ModuleName
       iDeclToModName = unLoc . ideclName
 
@@ -319,8 +315,7 @@ cacheDataProducer packageState curMod rdrEnv limports deps = do
           (, mempty) <$> toCompItem curMod curModName n Nothing
       getComplsForOne (GRE n _ False prov) =
         flip foldMapM (map is_decl prov) $ \spec -> do
-          let originalImportDecl = Map.lookup (is_dloc spec) importMap
-          compItem <- toCompItem curMod (is_mod spec) n originalImportDecl
+          compItem <- toCompItem curMod (is_mod spec) n Nothing
           let unqual
                 | is_qual spec = []
                 | otherwise = compItem

--- a/test/exe/Main.hs
+++ b/test/exe/Main.hs
@@ -2952,34 +2952,6 @@ nonLocalCompletionTests =
       [ ("permutations", CiFunction, "permutations ${1:[a]}", False, False, Nothing)
       ],
     completionTest
-      "show imports not in list - simple"
-      ["{-# LANGUAGE NoImplicitPrelude #-}",
-       "module A where", "import Control.Monad (msum)", "f = joi"]
-      (Position 3 6)
-      [("join", CiFunction, "join ${1:m (m a)}", False, False,
-        Just (List [TextEdit {_range = Range {_start = Position {_line = 2, _character = 26}, _end = Position {_line = 2, _character = 26}}, _newText = "join, "}]))],
-    completionTest
-      "show imports not in list - multi-line"
-      ["{-# LANGUAGE NoImplicitPrelude #-}",
-       "module A where", "import Control.Monad (\n    msum)", "f = joi"]
-      (Position 4 6)
-      [("join", CiFunction, "join ${1:m (m a)}", False, False,
-        Just (List [TextEdit {_range = Range {_start = Position {_line = 3, _character = 8}, _end = Position {_line = 3, _character = 8}}, _newText = "join, "}]))],
-    completionTest
-      "show imports not in list - names with _"
-      ["{-# LANGUAGE NoImplicitPrelude #-}",
-       "module A where", "import qualified Control.Monad as M (msum)", "f = M.mapM_"]
-      (Position 3 11)
-      [("mapM_", CiFunction, "mapM_ ${1:a -> m b} ${2:t a}", False, False,
-        Just (List [TextEdit {_range = Range {_start = Position {_line = 2, _character = 41}, _end = Position {_line = 2, _character = 41}}, _newText = "mapM_, "}]))],
-    completionTest
-      "show imports not in list - initial empty list"
-      ["{-# LANGUAGE NoImplicitPrelude #-}",
-       "module A where", "import qualified Control.Monad as M ()", "f = M.joi"]
-      (Position 3 10)
-      [("join", CiFunction, "join ${1:m (m a)}", False, False,
-        Just (List [TextEdit {_range = Range {_start = Position {_line = 2, _character = 37}, _end = Position {_line = 2, _character = 37}}, _newText = "join, "}]))],
-    completionTest
        "dont show hidden items"
        [ "{-# LANGUAGE NoImplicitPrelude #-}",
          "module A where",
@@ -2988,16 +2960,47 @@ nonLocalCompletionTests =
        ]
        (Position 3 6)
        [],
-    completionTest
-      "record snippet on import"
-      ["module A where", "import Text.Printf (FormatParse(FormatParse))", "FormatParse"]
-      (Position 2 10)
-      [("FormatParse", CiStruct, "FormatParse ", False, False,
-       Just (List [TextEdit {_range = Range {_start = Position {_line = 1, _character = 44}, _end = Position {_line = 1, _character = 44}}, _newText = "FormatParse, "}])),
-       ("FormatParse", CiConstructor, "FormatParse ${1:String} ${2:Char} ${3:String}", False, False,
-       Just (List [TextEdit {_range = Range {_start = Position {_line = 1, _character = 44}, _end = Position {_line = 1, _character = 44}}, _newText = "FormatParse, "}])),
-       ("FormatParse", CiSnippet, "FormatParse {fpModifiers=${1:_fpModifiers}, fpChar=${2:_fpChar}, fpRest=${3:_fpRest}}", False, False,
-       Just (List [TextEdit {_range = Range {_start = Position {_line = 1, _character = 44}, _end = Position {_line = 1, _character = 44}}, _newText = "FormatParse, "}]))
+    expectFailBecause "Auto import completion snippets were disabled in v0.6.0.2" $
+      testGroup "auto import snippets"
+      [ completionTest
+        "show imports not in list - simple"
+        ["{-# LANGUAGE NoImplicitPrelude #-}",
+        "module A where", "import Control.Monad (msum)", "f = joi"]
+        (Position 3 6)
+        [("join", CiFunction, "join ${1:m (m a)}", False, False,
+            Just (List [TextEdit {_range = Range {_start = Position {_line = 2, _character = 26}, _end = Position {_line = 2, _character = 26}}, _newText = "join, "}]))]
+      , completionTest
+        "show imports not in list - multi-line"
+        ["{-# LANGUAGE NoImplicitPrelude #-}",
+        "module A where", "import Control.Monad (\n    msum)", "f = joi"]
+        (Position 4 6)
+        [("join", CiFunction, "join ${1:m (m a)}", False, False,
+            Just (List [TextEdit {_range = Range {_start = Position {_line = 3, _character = 8}, _end = Position {_line = 3, _character = 8}}, _newText = "join, "}]))]
+      , completionTest
+        "show imports not in list - names with _"
+        ["{-# LANGUAGE NoImplicitPrelude #-}",
+        "module A where", "import qualified Control.Monad as M (msum)", "f = M.mapM_"]
+        (Position 3 11)
+        [("mapM_", CiFunction, "mapM_ ${1:a -> m b} ${2:t a}", False, False,
+            Just (List [TextEdit {_range = Range {_start = Position {_line = 2, _character = 41}, _end = Position {_line = 2, _character = 41}}, _newText = "mapM_, "}]))]
+      , completionTest
+        "show imports not in list - initial empty list"
+        ["{-# LANGUAGE NoImplicitPrelude #-}",
+        "module A where", "import qualified Control.Monad as M ()", "f = M.joi"]
+        (Position 3 10)
+        [("join", CiFunction, "join ${1:m (m a)}", False, False,
+            Just (List [TextEdit {_range = Range {_start = Position {_line = 2, _character = 37}, _end = Position {_line = 2, _character = 37}}, _newText = "join, "}]))]
+      , completionTest
+        "record snippet on import"
+        ["module A where", "import Text.Printf (FormatParse(FormatParse))", "FormatParse"]
+        (Position 2 10)
+        [("FormatParse", CiStruct, "FormatParse ", False, False,
+        Just (List [TextEdit {_range = Range {_start = Position {_line = 1, _character = 44}, _end = Position {_line = 1, _character = 44}}, _newText = "FormatParse, "}])),
+        ("FormatParse", CiConstructor, "FormatParse ${1:String} ${2:Char} ${3:String}", False, False,
+        Just (List [TextEdit {_range = Range {_start = Position {_line = 1, _character = 44}, _end = Position {_line = 1, _character = 44}}, _newText = "FormatParse, "}])),
+        ("FormatParse", CiSnippet, "FormatParse {fpModifiers=${1:_fpModifiers}, fpChar=${2:_fpChar}, fpRest=${3:_fpRest}}", False, False,
+        Just (List [TextEdit {_range = Range {_start = Position {_line = 1, _character = 44}, _end = Position {_line = 1, _character = 44}}, _newText = "FormatParse, "}]))
+        ]
       ],
       -- we need this test to make sure the ghcide completions module does not return completions for language pragmas. this functionality is turned on in hls
      completionTest


### PR DESCRIPTION
This is a point release to disable the auto extend import snippets from completions because of the issues reported in https://github.com/haskell/haskell-language-server/issues/679