### PR TITLE
Fix diagnostics update bug

### DIFF
--- a/bench/lib/Experiments.hs
+++ b/bench/lib/Experiments.hs
@@ -115,7 +115,13 @@ experiments =
         )
         ( \p doc -> do
             changeDoc doc [hygienicEdit]
-            whileM (null <$> waitForDiagnostics)
+            waitForProgressDone
+            -- NOTE ghcide used to clear and reinstall the diagnostics here
+            -- new versions no longer do, but keep this logic around
+            -- to benchmark old versions sucessfully
+            diags <- getCurrentDiagnostics doc
+            when (null diags) $
+              whileM (null <$> waitForDiagnostics)
             not . null <$> getCodeActions doc (Range p p)
         )
     ]

--- a/exe/Arguments.hs
+++ b/exe/Arguments.hs
@@ -14,6 +14,7 @@ data Arguments = Arguments
     ,argsShakeProfiling :: Maybe FilePath
     ,argsOTMemoryProfiling :: Bool
     ,argsTesting :: Bool
+    ,argsDisableKick :: Bool
     ,argsThreads :: Int
     ,argsVerbose :: Bool
     }
@@ -35,5 +36,6 @@ arguments = Arguments
       <*> optional (strOption $ long "shake-profiling" <> metavar "DIR" <> help "Dump profiling reports to this directory")
       <*> switch (long "ot-memory-profiling" <> help "Record OpenTelemetry info to the eventlog. Needs the -l RTS flag to have an effect")
       <*> switch (long "test" <> help "Enable additional lsp messages used by the testsuite")
+      <*> switch (long "test-no-kick" <> help "Disable kick. Useful for testing cancellation")
       <*> option auto (short 'j' <> help "Number of threads (0: automatic)" <> metavar "NUM" <> value 0 <> showDefault)
       <*> switch (long "verbose" <> help "Include internal events in logging output")

--- a/exe/Main.hs
+++ b/exe/Main.hs
@@ -118,7 +118,15 @@ main = do
                     }
                 logLevel = if argsVerbose then minBound else Info
             debouncer <- newAsyncDebouncer
-            initialise caps (mainRule >> pluginRules plugins >> action kick)
+            let rules = do
+                  -- install the main and ghcide-plugin rules
+                  mainRule
+                  pluginRules plugins
+                  -- install the kick action, which triggers a typecheck on every
+                  -- Shake database restart, i.e. on every user edit.
+                  unless argsDisableKick $
+                    action kick
+            initialise caps rules
                 getLspId event wProg wIndefProg (logger logLevel) debouncer options vfs
     else do
         -- GHC produces messages with UTF8 in them, so make sure the terminal doesn't error

--- a/ghcide.cabal
+++ b/ghcide.cabal
@@ -41,6 +41,7 @@ library
         base == 4.*,
         binary,
         bytestring,
+        case-insensitive,
         containers,
         data-default,
         deepseq,

--- a/src/Development/IDE.hs
+++ b/src/Development/IDE.hs
@@ -28,7 +28,6 @@ import Development.IDE.Core.Shake as X
     ShakeExtras,
     IdeRule,
     define, defineEarlyCutoff,
-    GetModificationTime(GetModificationTime),
     use, useNoFile, uses, useWithStale, useWithStaleFast, useWithStaleFast',
     FastResult(..),
     use_, useNoFile_, uses_, useWithStale_,

--- a/src/Development/IDE/Core/FileStore.hs
+++ b/src/Development/IDE/Core/FileStore.hs
@@ -28,7 +28,6 @@ import           Control.Monad.Extra
 import           Development.Shake
 import           Development.Shake.Classes
 import           Control.Exception
-import           GHC.Generics
 import Data.Either.Extra
 import Data.Int (Int64)
 import Data.Time
@@ -99,15 +98,6 @@ isFileOfInterestRule = defineEarlyCutoff $ \IsFileOfInterest f -> do
     filesOfInterest <- getFilesOfInterest
     let res = maybe NotFOI IsFOI $ f `HM.lookup` filesOfInterest
     return (Just $ BS.pack $ show $ hash res, ([], Just res))
-
--- | Get the contents of a file, either dirty (if the buffer is modified) or Nothing to mean use from disk.
-type instance RuleResult GetFileContents = (FileVersion, Maybe T.Text)
-
-data GetFileContents = GetFileContents
-    deriving (Eq, Show, Generic)
-instance Hashable GetFileContents
-instance NFData   GetFileContents
-instance Binary   GetFileContents
 
 getModificationTimeRule :: VFSHandle -> Rules ()
 getModificationTimeRule vfs =

--- a/src/Development/IDE/Core/Service.hs
+++ b/src/Development/IDE/Core/Service.hs
@@ -13,7 +13,7 @@ module Development.IDE.Core.Service(
     IdeState, initialise, shutdown,
     runAction,
     writeProfile,
-    getDiagnostics, unsafeClearDiagnostics,
+    getDiagnostics,
     ideLogger,
     updatePositionMapping,
     ) where

--- a/src/Development/IDE/Core/Shake.hs
+++ b/src/Development/IDE/Core/Shake.hs
@@ -1058,7 +1058,7 @@ setStageDiagnostics uri ver stage diags ds = newDiagsStore where
     -- from other stages when calling updateDiagnostics
     -- But this means that updateDiagnostics cannot be called concurrently
     -- for different stages anymore
-    updatedDiags = Map.singleton (Just stage) (SL.toSortedList diags) <> oldDiags
+    updatedDiags = Map.insert (Just stage) (SL.toSortedList diags) oldDiags
     oldDiags = case HMap.lookup uri ds of
             Just (StoreItem _ byStage) -> byStage
             _ -> Map.empty

--- a/src/Development/IDE/Core/Shake.hs
+++ b/src/Development/IDE/Core/Shake.hs
@@ -7,7 +7,6 @@
 {-# LANGUAGE RecursiveDo #-}
 {-# LANGUAGE TypeFamilies               #-}
 {-# LANGUAGE ConstraintKinds            #-}
-{-# LANGUAGE PatternSynonyms            #-}
 
 -- | A Shake implementation of the compiler service.
 --

--- a/src/Development/IDE/Core/Shake.hs
+++ b/src/Development/IDE/Core/Shake.hs
@@ -502,7 +502,7 @@ shakeShut IdeState{..} = withMVar shakeSession $ \runner -> do
 -- | This is a variant of withMVar where the first argument is run unmasked and if it throws
 -- an exception, the previous value is restored while the second argument is executed masked.
 withMVar' :: MVar a -> (a -> IO b) -> (b -> IO (a, c)) -> IO c
-withMVar' var unmasked masked = mask $ \restore -> do
+withMVar' var unmasked masked = uninterruptibleMask $ \restore -> do
     a <- takeMVar var
     b <- restore (unmasked a) `onException` putMVar var a
     (a', c) <- masked b

--- a/src/Development/IDE/Core/Shake.hs
+++ b/src/Development/IDE/Core/Shake.hs
@@ -38,7 +38,7 @@ module Development.IDE.Core.Shake(
     useWithStale, usesWithStale,
     useWithStale_, usesWithStale_,
     define, defineEarlyCutoff, defineOnDisk, needOnDisk, needOnDisks,
-    getDiagnostics, unsafeClearDiagnostics,
+    getDiagnostics,
     getHiddenDiagnostics,
     IsIdeGlobal, addIdeGlobal, addIdeGlobalExtras, getIdeGlobalState, getIdeGlobalAction,
     getIdeGlobalExtras,
@@ -651,11 +651,6 @@ getHiddenDiagnostics :: IdeState -> IO [FileDiagnostic]
 getHiddenDiagnostics IdeState{shakeExtras = ShakeExtras{hiddenDiagnostics}} = do
     val <- readVar hiddenDiagnostics
     return $ getAllDiagnostics val
-
--- | FIXME: This function is temporary! Only required because the files of interest doesn't work
-unsafeClearDiagnostics :: IdeState -> IO ()
-unsafeClearDiagnostics IdeState{shakeExtras = ShakeExtras{diagnostics}} =
-    writeVar diagnostics mempty
 
 -- | Clear the results for all files that do not match the given predicate.
 garbageCollect :: (NormalizedFilePath -> Bool) -> Action ()

--- a/src/Development/IDE/Plugin/Test.hs
+++ b/src/Development/IDE/Plugin/Test.hs
@@ -94,6 +94,7 @@ mkResponseError msg = ResponseError InvalidRequest msg Nothing
 
 parseAction :: CI String -> NormalizedFilePath -> Action (Either Text Bool)
 parseAction "typecheck" fp = Right . isJust <$> use TypeCheck fp
+parseAction "getLocatedImports" fp = Right . isJust <$> use GetLocatedImports fp
 parseAction "getmodsummary" fp = Right . isJust <$> use GetModSummary fp
 parseAction "getmodsummarywithouttimestamps" fp = Right . isJust <$> use GetModSummaryWithoutTimestamps fp
 parseAction "getparsedmodule" fp = Right . isJust <$> use GetParsedModule fp

--- a/src/Development/IDE/Plugin/Test.hs
+++ b/src/Development/IDE/Plugin/Test.hs
@@ -1,11 +1,16 @@
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DerivingStrategies #-}
 -- | A plugin that adds custom messages for use in tests
-module Development.IDE.Plugin.Test (TestRequest(..), plugin) where
+module Development.IDE.Plugin.Test
+  ( TestRequest(..)
+  , WaitForIdeRuleResult(..)
+  , plugin
+  ) where
 
 import Control.Monad.STM
 import Data.Aeson
 import Data.Aeson.Types
+import Data.CaseInsensitive (CI, original)
 import Development.IDE.Core.Service
 import Development.IDE.Core.Shake
 import Development.IDE.GHC.Compat
@@ -21,15 +26,24 @@ import Language.Haskell.LSP.Types
 import System.Time.Extra
 import Development.IDE.Core.RuleTypes
 import Control.Monad
+import Development.Shake (Action)
+import Data.Maybe (isJust)
+import Data.Bifunctor
+import Data.Text (pack, Text)
+import Data.String
+import Development.IDE.Types.Location (fromUri)
 
 data TestRequest
     = BlockSeconds Seconds           -- ^ :: Null
     | GetInterfaceFilesDir FilePath  -- ^ :: String
     | GetShakeSessionQueueCount      -- ^ :: Number
-    | WaitForShakeQueue
-      -- ^ Block until the Shake queue is empty. Returns Null
+    | WaitForShakeQueue -- ^ Block until the Shake queue is empty. Returns Null
+    | WaitForIdeRule String Uri      -- ^ :: WaitForIdeRuleResult
     deriving Generic
     deriving anyclass (FromJSON, ToJSON)
+
+newtype WaitForIdeRuleResult = WaitForIdeRuleResult { ideResultSuccess::Bool}
+    deriving newtype (FromJSON, ToJSON)
 
 plugin :: Plugin c
 plugin = Plugin {
@@ -69,4 +83,23 @@ requestHandler _ s WaitForShakeQueue = do
         n <- countQueue $ actionQueue $ shakeExtras s
         when (n>0) retry
     return $ Right Null
+requestHandler _ s (WaitForIdeRule k file) = do
+    let nfp = fromUri $ toNormalizedUri file
+    success <- runAction ("WaitForIdeRule " <> k <> " " <> show file) s $ parseAction (fromString k) nfp
+    let res = WaitForIdeRuleResult <$> success
+    return $ bimap mkResponseError toJSON res
 
+mkResponseError :: Text -> ResponseError
+mkResponseError msg = ResponseError InvalidRequest msg Nothing
+
+parseAction :: CI String -> NormalizedFilePath -> Action (Either Text Bool)
+parseAction "typecheck" fp = Right . isJust <$> use TypeCheck fp
+parseAction "getmodsummary" fp = Right . isJust <$> use GetModSummary fp
+parseAction "getmodsummarywithouttimestamps" fp = Right . isJust <$> use GetModSummaryWithoutTimestamps fp
+parseAction "getparsedmodule" fp = Right . isJust <$> use GetParsedModule fp
+parseAction "ghcsession" fp = Right . isJust <$> use GhcSession fp
+parseAction "ghcsessiondeps" fp = Right . isJust <$> use GhcSessionDeps fp
+parseAction "gethieast" fp = Right . isJust <$> use GetHieAst fp
+parseAction "getDependencies" fp = Right . isJust <$> use GetDependencies fp
+parseAction "getFileContents" fp = Right . isJust <$> use GetFileContents fp
+parseAction other _ = return $ Left $ "Cannot parse ide rule: " <> pack (original other)

--- a/test/exe/Main.hs
+++ b/test/exe/Main.hs
@@ -58,7 +58,7 @@ import Test.Tasty.HUnit
 import Test.Tasty.QuickCheck
 import System.Time.Extra
 import Development.IDE.Plugin.CodeAction (typeSignatureCommandId, blockCommandId, matchRegExMultipleImports)
-import Development.IDE.Plugin.Test (TestRequest(WaitForIdeRule, BlockSeconds,GetInterfaceFilesDir))
+import Development.IDE.Plugin.Test (WaitForIdeRuleResult(..), TestRequest(WaitForIdeRule, BlockSeconds,GetInterfaceFilesDir))
 import Control.Monad.Extra (whenJust)
 
 main :: IO ()
@@ -570,7 +570,7 @@ diagnosticTests = testGroup "diagnostics"
         ,TextDocumentContentChangeEvent {_range=Just (Range p p'), _rangeLength=Nothing, _text=""})
       editHeader = editPair 0 0
       editImport = editPair 2 10
-      editBody   = editPair 4 10
+      editBody   = editPair 3 10
 
       noParse = False
       yesParse = True
@@ -602,46 +602,46 @@ cancellationTestGroup name edits dependsOutcome sessionDepsOutcome parseOutcome 
     ]
 
 cancellationTemplate :: (TextDocumentContentChangeEvent, TextDocumentContentChangeEvent) -> Maybe (String, Bool) -> TestTree
-cancellationTemplate (edit, undoEdit) mbKey = testSessionWait (maybe "-" fst mbKey) $ do
-      let fooContent = T.unlines
+cancellationTemplate (edit, undoEdit) mbKey = testCase (maybe "-" fst mbKey) $ runTestNoKick $ do
+      doc <- createDoc "Foo.hs" "haskell" $ T.unlines
             [ "{-# OPTIONS_GHC -Wall #-}"
             , "module Foo where"
             , "import Data.List()"
             , "f0 x = (x,x)"
-            , "f1 x = f0 (f0 x)"
-            , "f2 x = f1 (f1 x)"
-            , "f3 x = f2 (f2 x)"
             ]
-      doc@TextDocumentIdentifier{..} <- createDoc "Foo.hs" "haskell" fooContent
-      let docNfp = fromNormalizedFilePath $ fromUri $ toNormalizedUri _uri
 
-      -- for the example above we expect 4 warnings due to missing type sigs
-      let missingSigDiags =
-              [(DsWarning, (3, 0), "Top-level binding")
-              ,(DsWarning, (4, 0), "Top-level binding")
-              ,(DsWarning, (5, 0), "Top-level binding")
-              ,(DsWarning, (6, 0), "Top-level binding")
-              ]
-      expectDiagnostics [("Foo.hs", missingSigDiags)]
+      -- for the example above we expect one warning
+      let missingSigDiags = [(DsWarning, (3, 0), "Top-level binding") ]
+      typeCheck doc >> expectCurrentDiagnostics doc missingSigDiags
 
       -- Now we edit the document and wait for the given key (if any)
       changeDoc doc [edit]
       whenJust mbKey $ \(key, expectedResult) -> do
-        waitId <- sendRequest (CustomClientMethod "test") (WaitForIdeRule key docNfp)
-        ResponseMessage{_result} <- skipManyTill anyMessage $ responseForId waitId
-        liftIO $ _result @?= Right expectedResult
+        Right WaitForIdeRuleResult{ideResultSuccess} <- waitForAction key doc
+        liftIO $ ideResultSuccess @?= expectedResult
 
       -- The 2nd edit cancels the active session and unbreaks the file
+      -- wait for typecheck and check that the current diagnostics are accurate
       changeDoc doc [undoEdit]
+      typeCheck doc >> expectCurrentDiagnostics doc missingSigDiags
 
-      -- finally, wait for typecheck and check that the current diagnostics are accurate
-      waitId <- sendRequest (CustomClientMethod "test") (WaitForIdeRule "typecheck" docNfp)
-      ResponseMessage{_result} <- skipManyTill anyMessage $ responseForId waitId
-      liftIO $ sleep 0.2
-      liftIO $ _result @?= Right True
+      expectNoMoreDiagnostics 0.5
+    where
+        -- similar to run except it disables kick
+        runTestNoKick s = withTempDir $ \dir -> runInDir' dir "." "." ["--test-no-kick"] s
 
-      expectCurrentDiagnostics doc missingSigDiags
+        waitForAction key TextDocumentIdentifier{_uri} = do
+            waitId <- sendRequest (CustomClientMethod "test") (WaitForIdeRule key _uri)
+            ResponseMessage{_result} <- skipManyTill anyMessage $ responseForId waitId
+            return _result
 
+        typeCheck doc = do
+            Right WaitForIdeRuleResult {..} <- waitForAction "TypeCheck" doc
+            liftIO $ assertBool "The file should typecheck" ideResultSuccess
+            -- wait for the debouncer to publish diagnostics if the rule runs
+            liftIO $ sleep 0.2
+            -- flush messages to ensure current diagnostics state is updated
+            flushMessages
 
 codeActionTests :: TestTree
 codeActionTests = testGroup "code actions"
@@ -3737,7 +3737,7 @@ rootUriTests = testCase "use rootUri" . runTest "dirA" "dirB" $ \dir -> do
   where
     -- similar to run' except we can configure where to start ghcide and session
     runTest :: FilePath -> FilePath -> (FilePath -> Session ()) -> IO ()
-    runTest dir1 dir2 s = withTempDir $ \dir -> runInDir' dir dir1 dir2 (s dir)
+    runTest dir1 dir2 s = withTempDir $ \dir -> runInDir' dir dir1 dir2 [] (s dir)
 
 -- | Test if ghcide asynchronously handles Commands and user Requests
 asyncTests :: TestTree
@@ -3850,11 +3850,11 @@ run' :: (FilePath -> Session a) -> IO a
 run' s = withTempDir $ \dir -> runInDir dir (s dir)
 
 runInDir :: FilePath -> Session a -> IO a
-runInDir dir = runInDir' dir "." "."
+runInDir dir = runInDir' dir "." "." []
 
 -- | Takes a directory as well as relative paths to where we should launch the executable as well as the session root.
-runInDir' :: FilePath -> FilePath -> FilePath -> Session a -> IO a
-runInDir' dir startExeIn startSessionIn s = do
+runInDir' :: FilePath -> FilePath -> FilePath -> [String] -> Session a -> IO a
+runInDir' dir startExeIn startSessionIn extraOptions s = do
   ghcideExe <- locateGhcideExecutable
   let startDir = dir </> startExeIn
   let projDir = dir </> startSessionIn
@@ -3865,7 +3865,8 @@ runInDir' dir startExeIn startSessionIn s = do
   -- since the package import test creates "Data/List.hs", which otherwise has no physical home
   createDirectoryIfMissing True $ projDir ++ "/Data"
 
-  let cmd = unwords [ghcideExe, "--lsp", "--test", "--verbose", "--cwd", startDir]
+  let cmd = unwords $
+       [ghcideExe, "--lsp", "--test", "--verbose", "--cwd", startDir] ++ extraOptions
   -- HIE calls getXgdDirectory which assumes that HOME is set.
   -- Only sets HOME if it wasn't already set.
   setEnv "HOME" "/homeless-shelter" False


### PR DESCRIPTION
Given a FOI F with non null typechecking diagnostics D, imagine the following scenario:

1. An edit notification for F is received, creating a new version
2. GetModTime is executed, producing 0 diagnostics.
  2.1 updateFileDiagnostics is called
  2.2 setStageDiagnostics is called
  2.3 LSP.updateDiagnostics is called with a new version, resetting all the
  diagnostics for F
  2.4 newDiags=[] in updateFileDiagnostics, which is different from D (the last
  published diagnostics), which enqueues a new publishDiagnostics [] in the
  Debouncer
3. An edit notification for F is received before typechecking has a chance to
run which undoes the previous edit
4. The debouncer publishes the empty set of diagnostics after waiting 0.1s
5. GetFileContents runs and since the contents of the file haven't changed since
the last time it ran, early cutoff skips everything donwstream

Since TypeCheck is skipped, the empty set of diagnostics stays published until
another edit comes. This is a bug.

The goal of this change is to prevent setStageDiagnostics from losing
diagnostics from other stages. To achieve this, we recover the old diagnostics
for all stages and merge them with the new stage.

Fixes #949

The test suite includes a new custom command that can be used to wait for arbitrary Shake actions, which can be used to implement the improvements outlined in #955 